### PR TITLE
Add fallback fix for breakpoint-control

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -39,6 +39,13 @@
     // Ensure the drawer is hidden on desktop/tablet
     var drawerPanel = document.querySelector('#paperDrawerPanel');
     drawerPanel.forceNarrow = true;
+
+    // Fallback html class in case were are
+    // unable to determine a suitable breakpoint
+    var html = document.querySelector('html');
+    if (html.classList.length === 0) {
+      html.classList.add('mobile-small');
+    }
   });
 
 })(document);


### PR DESCRIPTION
Breakpoint control has an odd timing bug that occasionally fails to determine/set the html class of the app, causing layout breakage. This patch ensures that if no body class is set, we supply a default one.

review: @blasten 
