### PR TITLE
Adds equal left and right padding to paper-material

### DIFF
--- a/app/elements/app-theme.html
+++ b/app/elements/app-theme.html
@@ -132,8 +132,9 @@ paper-menu a {
 
   paper-material {
     --menu-container-display: none;
-    width: calc(97.33% - 16px);
+    width: calc(97.33% - 32px);
     padding-left: 16px;
+    padding-right: 16px;
   }
 
   #drawer .paper-toolbar {
@@ -166,8 +167,9 @@ paper-menu a {
 @media (min-width: 601px) {
 
   paper-material {
-    width: calc(98% - 16px);
+    width: calc(98% - 46px);
     padding-left: 30px;
+    padding-right: 30px;
   }
 
 }


### PR DESCRIPTION
Currently the paper material has no right padding which causes content to touch the edges of the paper on the right side:

![mobile](https://cloud.githubusercontent.com/assets/296130/7892040/1bb7d166-0617-11e5-91fb-4f2b27f6965f.jpg)

This fixes that. Thanks!

![equal-padding](https://cloud.githubusercontent.com/assets/296130/7892044/2331baa6-0617-11e5-8355-4e248b93fe3a.jpg)
