### PR TITLE
Avoid installing global dependencies and use npm scripts for quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,16 +25,17 @@ To take advantage of Polymer Starter Kit you need to:
 
 [Download](https://github.com/polymerelements/polymer-starter-kit/releases/latest) and extract Polymer Starter Kit to where you want to work.
 
-### Install dependencies
+### Quick start
 
-With [Node.js](http://nodejs.org) and npm installed, run:
+With [Node.js](http://nodejs.org) installed, run:
 
 ```sh
-$ npm run deps
+git clone https://github.com/PolymerElements/polymer-starter-kit.git
+cd polymer-starter-kit
+npm start
 ```
 
-This will install the element sets (Paper, Iron, Platinum) and tools
-we will use to serve and build apps.
+This will install all the dependencies including npm dependencies, Bower components and the element sets (Paper, Iron, Platinum), then it will start the app in development mode.
 
 ### Serve / watch
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "prebower-install": "npm install",
     "bower-install": "bower install",
     "prestart": "npm run bower-install",
-    "start": "gulp serve"
+    "start": "gulp serve",
+    "test": "gulp test"
   },
   "devDependencies": {
     "apache-server-configs": "^2.7.1",

--- a/package.json
+++ b/package.json
@@ -3,10 +3,14 @@
   "version": "0.0.0",
   "dependencies": {},
   "scripts": {
-    "deps": "npm install -g gulp && npm install -g bower && npm install && bower install"
+    "prebower-install": "npm install",
+    "bower-install": "bower install",
+    "prestart": "npm run bower-install",
+    "start": "gulp serve"
   },
   "devDependencies": {
     "apache-server-configs": "^2.7.1",
+    "bower": "^1.4.1",
     "browser-sync": "^2.6.4",
     "del": "^1.1.1",
     "glob": "^5.0.6",


### PR DESCRIPTION
This will make it simpler to jump start with the project without having to install global dependencies. npm will use local `node_modules/.bin` folder for bower and gulp. 