### PR TITLE
fixes #mainToolbar padding

### DIFF
--- a/app/elements/app-theme.html
+++ b/app/elements/app-theme.html
@@ -172,6 +172,13 @@ paper-menu a {
     padding-right: 30px;
   }
 
+    #mainToolbar.has-shadow .bottom {
+        margin-left: 50px;
+        padding-bottom: 0;
+        padding-left: 0;
+        font-size: 24px;
+    }
+
 }
 
 /* Material Design Adaptive Breakpoints */

--- a/app/elements/app-theme.html
+++ b/app/elements/app-theme.html
@@ -71,7 +71,7 @@ paper-menu iron-icon {
 }
 
 #mainToolbar .bottom {
-  padding-bottom: 100px;
+  padding-bottom: 120px;
   padding-left: 30px;
 }
 


### PR DESCRIPTION
Otherwise {{appTitle}} is still visible when you scroll and flatten the waterfall-tall toolbar