### PR TITLE
A single line for installing deps causes problems on Ubuntu.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,18 @@ To take advantage of Polymer Starter Kit you need to:
 
 ### Install dependencies
 
-With [Node.js](http://nodejs.org) and npm installed, run the following one liner from the root of your Polymer Starter Kit download:
+With [Node.js](http://nodejs.org) and npm installed, run the following line from the root of your Polymer Starter Kit download to install the Node dependencies:
 
+Use "sudo" if needed (Ubuntu).
 ```sh
-$ npm install -g gulp && npm install -g bower && npm install && bower install
+$ npm run node-deps
+```
+
+Now install the app dependencies:
+
+Do not use "sudo" here.
+```sh
+$ npm run app-deps
 ```
 
 This will install the element sets (Paper, Iron, Platinum) and tools

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "polymer-starter-kit",
   "version": "0.0.0",
   "dependencies": {},
+  "scripts": {
+    "node-deps": "npm install -g gulp && npm install -g bower && npm install",
+    "app-deps": "bower install"
+  },
   "devDependencies": {
     "apache-server-configs": "^2.7.1",
     "browser-sync": "^2.6.4",


### PR DESCRIPTION
On Ubuntu the following command must be executed with "sudo", otherwise the user gets an access rights error.

On the other hand, if the Ubuntu user issues the command using "sudo", Bower will complain.

My proposed solution is to divide the one liner command into node-deps and app-deps and move them back to package.json.

```
"scripts": {
    "node-deps": "npm install -g gulp && npm install -g bower && npm install",
    "app-deps": "bower install"
  }
```

I tested the modified installation instruction on Ubuntu 14.04 64 with NodeJS 0.12 from nodesource repository.

Everything seems to work fine, including serving the app, building the app and testing the app.

I haven't had the chance to test on different systems.
