### PR TITLE
Mark packages as private

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,6 @@
 {
   "name": "polymer-starter-kit",
-  "version": "0.0.0",
-  "license": "http://polymer.github.io/LICENSE.txt",
+  "private": true,
   "dependencies": {
     "iron-elements": "PolymerElements/iron-elements#1.0.0",
     "paper-elements": "PolymerElements/paper-elements#1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,5 @@
 {
-  "name": "polymer-starter-kit",
-  "version": "0.0.0",
-  "dependencies": {},
+  "private": true,
   "devDependencies": {
     "apache-server-configs": "^2.7.1",
     "browser-sync": "^2.6.4",


### PR DESCRIPTION
Marks the NPM and Bower package private, and as a result removes all needless properties. This prevents people from accidentally publishing it to the registry.

Also, keeping those properties up to date is a waste of time when you're not planning to publish it and only are planning to use those for devDependencies (which out of the box is the case). There's no deal with publishing a whole site to bower/npm so I guess this is the right choice to make.

Fix https://github.com/PolymerElements/polymer-starter-kit/issues/102
Ref https://github.com/PolymerElements/polymer-starter-kit/commit/1076cd7fba3743aec12f98ddd3fec69a2aa691a5
