### PR TITLE
Fixes #117 - menu alignment with spec

### DIFF
--- a/app/elements/app-theme.html
+++ b/app/elements/app-theme.html
@@ -73,7 +73,7 @@ paper-menu iron-icon {
 
 #mainToolbar .bottom {
   padding-bottom: 120px;
-  margin-left: 30px;
+  margin-left: 58px;
 }
 
 paper-menu a {
@@ -109,8 +109,8 @@ paper-menu a {
   border: none;
   color: var(--drawer-menu-color);
   background-color: transparent;
-  margin-right: 16px;
-  padding: 8px;
+  margin: -6px -6px 0px -6px;
+  padding: 12px;
 }
 
 /* Breakpoints */
@@ -160,8 +160,12 @@ paper-menu a {
   }
 
   .appname {
-    font-size: 24px;
+    font-size: 20px;
     padding-bottom: 0px;
+  }
+
+  #paperToggle {
+    margin-left: -14px;
   }
 }
 
@@ -173,12 +177,12 @@ paper-menu a {
     padding-right: 30px;
   }
 
-    #mainToolbar.has-shadow .bottom {
-        margin-left: 50px;
-        padding-bottom: 0;
-        padding-left: 0;
-        font-size: 24px;
-    }
+  #mainToolbar.has-shadow .bottom {
+    margin-left: 50px;
+    padding-bottom: 0;
+    padding-left: 0;
+    font-size: 24px;
+  }
 
 }
 


### PR DESCRIPTION
reviewer: @kenchris

Desktop:

Width of margin from window edge:
![screen shot 2015-06-04 at 14 57 20](https://cloud.githubusercontent.com/assets/110953/7985636/09d48248-0aca-11e5-9882-5701da8b09c3.png)

Height of margin from menu to top of screen:
![screen shot 2015-06-04 at 14 59 29](https://cloud.githubusercontent.com/assets/110953/7985685/5beca8e4-0aca-11e5-8769-ea9103f311a5.png)

Width of margin from end of menu to headline:
![screen shot 2015-06-04 at 14 58 20](https://cloud.githubusercontent.com/assets/110953/7985674/3eedfb4e-0aca-11e5-9047-f1731e557915.png)

Mobile:

Width of margin from edge:

![screen shot 2015-06-04 at 15 02 30](https://cloud.githubusercontent.com/assets/110953/7985725/c257e738-0aca-11e5-80f4-733dc3f4a79d.png)
