### PR TITLE
Layout and hamburger-menu improvements

### DIFF
--- a/app/elements/app-theme.html
+++ b/app/elements/app-theme.html
@@ -111,6 +111,9 @@ paper-menu a {
   background-color: transparent;
   margin: -6px -6px 0px -6px;
   padding: 12px;
+/* Height of the scroll area */
+.content {
+  height: 700px;
 }
 
 /* Breakpoints */

--- a/app/elements/app-theme.html
+++ b/app/elements/app-theme.html
@@ -10,200 +10,200 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <style is="custom-style">
 
-/*
- Polymer includes a shim for CSS Custom Properties that we can use for application theming.
- Below, you'll find the default palette for the Polymer Starter Kit layout. Feel free to play
- with changing the colors used or generate your own palette of colours at MaterialPalette.com.
+  /*
+   Polymer includes a shim for CSS Custom Properties that we can use for application theming.
+   Below, you'll find the default palette for the Polymer Starter Kit layout. Feel free to play
+   with changing the colors used or generate your own palette of colours at MaterialPalette.com.
 
- See https://www.polymer-project.org/1.0/docs/devguide/styling.html#xscope-styling-details
- for further information on custom CSS properties.
- */
+   See https://www.polymer-project.org/1.0/docs/devguide/styling.html#xscope-styling-details
+   for further information on custom CSS properties.
+   */
 
-/* Application theme */
+  /* Application theme */
 
-:root {
-  --dark-primary-color: #303F9F;
-  --default-primary-color:#3F51B5;
-  --light-primary-color: #C5CAE9;
-  --text-primary-color: #ffffff; /*text/icons*/
-  --accent-color: #FF4081;
-  --primary-background-color: #c5cae9;
-  --primary-text-color: #212121;
-  --secondary-text-color: #727272;
-  --disabled-text-color: #bdbdbd;
-  --divider-color: #B6B6B6;
+  :root {
+    --dark-primary-color: #303F9F;
+    --default-primary-color:#3F51B5;
+    --light-primary-color: #C5CAE9;
+    --text-primary-color: #ffffff; /*text/icons*/
+    --accent-color: #FF4081;
+    --primary-background-color: #c5cae9;
+    --primary-text-color: #212121;
+    --secondary-text-color: #727272;
+    --disabled-text-color: #bdbdbd;
+    --divider-color: #B6B6B6;
 
-  /* Components */
+    /* Components */
 
-  /* paper-drawer-panel */
-  --drawer-menu-color: #ffffff;
-  --drawer-border-color: 1px solid #ccc;
-  --drawer-toolbar-border-color: 1px solid rgba(0, 0, 0, 0.22);
+    /* paper-drawer-panel */
+    --drawer-menu-color: #ffffff;
+    --drawer-border-color: 1px solid #ccc;
+    --drawer-toolbar-border-color: 1px solid rgba(0, 0, 0, 0.22);
 
     /* paper-menu */
-  --paper-menu-background-color: #fff;
-  --menu-link-color: #111111;
-}
+    --paper-menu-background-color: #fff;
+    --menu-link-color: #111111;
+  }
 
-/* General styles */
+  /* General styles */
 
-#drawerToolbar {
-  border-bottom: var(--drawer-toolbar-border-color);
-  height: 120px;
-}
-
-paper-material {
-  border-radius: 2px;
-  height: 100%;
-  padding: 16px 0px 16px 0px;
-  width: calc(98.66% - 16px);
-  margin: 16px auto;
-  background: white;
-}
-
-paper-menu iron-icon {
-  margin-right: 33px;
-  opacity: 0.54;
-}
-
-.paper-menu > .iron-selected {
-  color: var(--default-primary-color);
-}
-
-paper-menu a {
-  text-decoration: none;
-  color: var(--menu-link-color);
-  display: -ms-flexbox;
-  display: -webkit-flex;
-  display: flex;
-  -ms-flex-direction: row;
-  -webkit-flex-direction: row;
-  flex-direction: row;
-  -ms-flex-align: center;
-  -webkit-align-items: center;
-  align-items: center;
-  font-family: 'Roboto', 'Noto', sans-serif;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  font-size: 14px;
-  font-weight: 400;
-  line-height: 24px;
-  min-height: 48px;
-  padding: 0px 16px;
-}
-
-#paperToggle {
-  border: none;
-  color: var(--drawer-menu-color);
-  background-color: transparent;
-  padding: 12px;
-  margin: 4px 4px 4px -14px;
-}
-
-#mainToolbar {
-  box-shadow: 0 4px 5px 0 rgba(0,0,0,.14),
-  0 2px 9px 1px rgba(0,0,0,.12),
-  0 4px 2px -2px rgba(0,0,0,.2);
-}
-
-#mainToolbar .middle {
-  margin-left: 48px;
-}
-
-#mainToolbar.has-shadow .middle {
-  font-size: 20px;
-  padding-bottom: 0px;
-  margin-left: 48px;
-}
-
-/* Height of the scroll area */
-.content {
-  height: 900px;
-}
-
-/* Breakpoints */
-
-/* Small */
-
-@media (max-width: 600px) {
+  #drawerToolbar {
+    border-bottom: var(--drawer-toolbar-border-color);
+    height: 120px;
+  }
 
   paper-material {
-    --menu-container-display: none;
-    width: calc(97.33% - 32px);
-    padding-left: 16px;
-    padding-right: 16px;
-  }
-
-  .paper-font-display1 {
-    font-size: 12px;
-  }
-
-  .appname {
-    font-size: 30px;
-  }
-
-  #drawer .paper-toolbar {
-    margin-left: 16px;
-  }
-
-  #overlay {
-    min-width: 360px;
-  }
-
-  .bg {
+    border-radius: 2px;
+    height: 100%;
+    padding: 16px 0px 16px 0px;
+    width: calc(98.66% - 16px);
+    margin: 16px auto;
     background: white;
   }
 
-}
-
-@media (min-width: 601px) {
-
-  paper-material {
-    width: calc(98% - 46px);
-    padding-left: 30px;
-    padding-right: 30px;
+  paper-menu iron-icon {
+    margin-right: 33px;
+    opacity: 0.54;
   }
-}
 
-/* Material Design Adaptive Breakpoints */
-/*
-  Below you'll find CSS media queries based on the breakpoint guidance
-  published by the Material Design team. You can choose to use, customise
-  or remove these breakpoints based on your needs.
+  .paper-menu > .iron-selected {
+    color: var(--default-primary-color);
+  }
 
-  http://www.google.com/design/spec/layout/adaptive-ui.html#adaptive-ui-breakpoints
- */
+  paper-menu a {
+    text-decoration: none;
+    color: var(--menu-link-color);
+    display: -ms-flexbox;
+    display: -webkit-flex;
+    display: flex;
+    -ms-flex-direction: row;
+    -webkit-flex-direction: row;
+    flex-direction: row;
+    -ms-flex-align: center;
+    -webkit-align-items: center;
+    align-items: center;
+    font-family: 'Roboto', 'Noto', sans-serif;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+    font-size: 14px;
+    font-weight: 400;
+    line-height: 24px;
+    min-height: 48px;
+    padding: 0px 16px;
+  }
 
-/* mobile-small */
-@media all and (min-width: 0px) and (max-width: 360px) and (orientation: portrait) { }
-/* mobile-large */
-@media all and (min-width: 361px) and (orientation: portrait) { }
-/* mobile-small-landscape */
-@media all and (min-width: 0px) and (max-width: 480px) and (orientation: landscape) { }
-/* mobile-large-landscape */
-@media all and (min-width: 481px) and (orientation: landscape) { }
-/* tablet-small-landscape */
-@media all and (min-width: 600px) and (max-width: 960px) and (orientation: landscape) { }
-/* tablet-large-landscape */
-@media all and (min-width: 961px) and (orientation: landscape) { }
-/* tablet-small */
-@media all and (min-width: 600px) and (orientation: portrait) { }
-/* tablet-large */
-@media all and (min-width: 601px) and (max-width: 840px) and (orientation : portrait) { }
-/* desktop-x-small-landscape */
-@media all and (min-width: 0px) and (max-width: 480px) and (orientation: landscape) { }
-/* desktop-x-small */
-@media all and (min-width: 0px) and (max-width: 480px) and (max-aspect-ratio: 4/3) { }
-/* desktop-small-landscape */
-@media all and (min-width: 481px) and (max-width: 840px) and (orientation: landscape) { }
-/* desktop-small */
-@media all and (min-width: 481px) and (max-width: 840px) and (max-aspect-ratio: 4/3) { }
-/* desktop-medium-landscape */
-@media all and (min-width: 841px) and (max-width: 1280px) and (orientation: landscape) { }
-/* desktop-medium */
-@media all and (min-width: 841px) and (max-width: 1280px) and (max-aspect-ratio: 4/3) { }
-/* desktop-large */
-@media all and (min-width: 1281px) and (max-width: 1600px) { }
-/* desktop-xlarge */
-@media all and (min-width: 1601px) and (max-width: 1920px) { }
+  #paperToggle {
+    border: none;
+    color: var(--drawer-menu-color);
+    background-color: transparent;
+    padding: 12px;
+    margin: 4px 4px 4px -14px;
+  }
+
+  #mainToolbar {
+    box-shadow: 0 4px 5px 0 rgba(0,0,0,.14),
+    0 2px 9px 1px rgba(0,0,0,.12),
+    0 4px 2px -2px rgba(0,0,0,.2);
+  }
+
+  #mainToolbar .middle {
+    margin-left: 48px;
+  }
+
+  #mainToolbar.has-shadow .middle {
+    font-size: 20px;
+    padding-bottom: 0px;
+    margin-left: 48px;
+  }
+
+  /* Height of the scroll area */
+  .content {
+    height: 900px;
+  }
+
+  /* Breakpoints */
+
+  /* Small */
+  @media (max-width: 600px) {
+
+    paper-material {
+      --menu-container-display: none;
+      width: calc(97.33% - 32px);
+      padding-left: 16px;
+      padding-right: 16px;
+    }
+
+    .paper-font-display1 {
+      font-size: 12px;
+    }
+
+    .app-name {
+      font-size: 26px;
+    }
+
+    #drawer .paper-toolbar {
+      margin-left: 16px;
+    }
+
+    #overlay {
+      min-width: 360px;
+    }
+
+    .bg {
+      background: white;
+    }
+
+  }
+
+  /* Tablet+ */
+  @media (min-width: 601px) {
+
+    paper-material {
+      width: calc(98% - 46px);
+      padding-left: 30px;
+      padding-right: 30px;
+    }
+  }
+
+  /* Material Design Adaptive Breakpoints */
+  /*
+    Below you'll find CSS media queries based on the breakpoint guidance
+    published by the Material Design team. You can choose to use, customise
+    or remove these breakpoints based on your needs.
+
+    http://www.google.com/design/spec/layout/adaptive-ui.html#adaptive-ui-breakpoints
+   */
+
+  /* mobile-small */
+  @media all and (min-width: 0px) and (max-width: 360px) and (orientation: portrait) { }
+  /* mobile-large */
+  @media all and (min-width: 361px) and (orientation: portrait) { }
+  /* mobile-small-landscape */
+  @media all and (min-width: 0px) and (max-width: 480px) and (orientation: landscape) { }
+  /* mobile-large-landscape */
+  @media all and (min-width: 481px) and (orientation: landscape) { }
+  /* tablet-small-landscape */
+  @media all and (min-width: 600px) and (max-width: 960px) and (orientation: landscape) { }
+  /* tablet-large-landscape */
+  @media all and (min-width: 961px) and (orientation: landscape) { }
+  /* tablet-small */
+  @media all and (min-width: 600px) and (orientation: portrait) { }
+  /* tablet-large */
+  @media all and (min-width: 601px) and (max-width: 840px) and (orientation : portrait) { }
+  /* desktop-x-small-landscape */
+  @media all and (min-width: 0px) and (max-width: 480px) and (orientation: landscape) { }
+  /* desktop-x-small */
+  @media all and (min-width: 0px) and (max-width: 480px) and (max-aspect-ratio: 4/3) { }
+  /* desktop-small-landscape */
+  @media all and (min-width: 481px) and (max-width: 840px) and (orientation: landscape) { }
+  /* desktop-small */
+  @media all and (min-width: 481px) and (max-width: 840px) and (max-aspect-ratio: 4/3) { }
+  /* desktop-medium-landscape */
+  @media all and (min-width: 841px) and (max-width: 1280px) and (orientation: landscape) { }
+  /* desktop-medium */
+  @media all and (min-width: 841px) and (max-width: 1280px) and (max-aspect-ratio: 4/3) { }
+  /* desktop-large */
+  @media all and (min-width: 1281px) and (max-width: 1600px) { }
+  /* desktop-xlarge */
+  @media all and (min-width: 1601px) and (max-width: 1920px) { }
 </style>

--- a/app/elements/app-theme.html
+++ b/app/elements/app-theme.html
@@ -47,6 +47,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 /* General styles */
 
+#drawerToolbar {
+  border-bottom: var(--drawer-toolbar-border-color);
+  height: 120px;
+}
+
 paper-material {
   border-radius: 2px;
   height: 100%;
@@ -54,12 +59,6 @@ paper-material {
   width: calc(98.66% - 16px);
   margin: 16px auto;
   background: white;
-}
-
-#mainToolbar {
-  box-shadow: 0 4px 5px 0 rgba(0,0,0,.14),
-  0 2px 9px 1px rgba(0,0,0,.12),
-  0 4px 2px -2px rgba(0,0,0,.2);
 }
 
 paper-menu iron-icon {
@@ -93,11 +92,6 @@ paper-menu a {
   padding: 0px 16px;
 }
 
-#drawerToolbar {
-  border-bottom: var(--drawer-toolbar-border-color);
-  height: 120px;
-}
-
 #paperToggle {
   border: none;
   color: var(--drawer-menu-color);
@@ -106,12 +100,17 @@ paper-menu a {
   margin: 4px 4px 4px -14px;
 }
 
-#mainToolbar .bottom {
-  padding-bottom: 120px;
+#mainToolbar {
+  box-shadow: 0 4px 5px 0 rgba(0,0,0,.14),
+  0 2px 9px 1px rgba(0,0,0,.12),
+  0 4px 2px -2px rgba(0,0,0,.2);
+}
+
+#mainToolbar .middle {
   margin-left: 48px;
 }
 
-#mainToolbar.has-shadow .appname {
+#mainToolbar.has-shadow .middle {
   font-size: 20px;
   padding-bottom: 0px;
   margin-left: 48px;
@@ -135,12 +134,12 @@ paper-menu a {
     padding-right: 16px;
   }
 
-  .paper-font-display2 {
-    font-size: 30px;
-  }
-
   .paper-font-display1 {
     font-size: 12px;
+  }
+
+  .appname {
+    font-size: 30px;
   }
 
   #drawer .paper-toolbar {

--- a/app/elements/app-theme.html
+++ b/app/elements/app-theme.html
@@ -73,7 +73,7 @@ paper-menu iron-icon {
 
 #mainToolbar .bottom {
   padding-bottom: 120px;
-  margin-left: 30px;
+  margin-left: 58px;
 }
 
 paper-menu a {
@@ -109,8 +109,8 @@ paper-menu a {
   border: none;
   color: var(--drawer-menu-color);
   background-color: transparent;
-  margin-right: 16px;
-  padding: 8px;
+  margin: -6px -6px 0px -6px;
+  padding: 12px;
 }
 
 /* Breakpoints */
@@ -160,8 +160,12 @@ paper-menu a {
   }
 
   .appname {
-    font-size: 24px;
+    font-size: 20px;
     padding-bottom: 0px;
+  }
+
+  #paperToggle {
+    margin-left: -14px;
   }
 }
 
@@ -173,12 +177,12 @@ paper-menu a {
     padding-right: 30px;
   }
 
-    #mainToolbar.has-shadow .bottom {
-        margin-left: 50px;
-        padding-bottom: 0;
-        padding-left: 0;
-        font-size: 24px;
-    }
+  #mainToolbar.has-shadow .bottom {
+    margin-left: 50px;
+    padding-bottom: 0;
+    padding-left: 0;
+    font-size: 24px;
+  }
 
 }
 

--- a/app/elements/app-theme.html
+++ b/app/elements/app-theme.html
@@ -103,24 +103,23 @@ paper-menu a {
   color: var(--drawer-menu-color);
   background-color: transparent;
   padding: 12px;
-  margin: 4px;
-  margin-left: -14px;
+  margin: 4px 4px 4px -14px;
 }
 
 #mainToolbar .bottom {
   padding-bottom: 120px;
-  margin-left: 36px;
+  margin-left: 48px;
 }
 
 #mainToolbar.has-shadow .appname {
   font-size: 20px;
   padding-bottom: 0px;
-  margin-left: 36px;
+  margin-left: 48px;
 }
 
 /* Height of the scroll area */
 .content {
-  height: 700px;
+  height: 900px;
 }
 
 /* Breakpoints */
@@ -128,7 +127,7 @@ paper-menu a {
 /* Small */
 
 @media (max-width: 600px) {
-  
+
   paper-material {
     --menu-container-display: none;
     width: calc(97.33% - 32px);

--- a/app/elements/app-theme.html
+++ b/app/elements/app-theme.html
@@ -71,11 +71,6 @@ paper-menu iron-icon {
   color: var(--default-primary-color);
 }
 
-#mainToolbar .bottom {
-  padding-bottom: 120px;
-  margin-left: 58px;
-}
-
 paper-menu a {
   text-decoration: none;
   color: var(--menu-link-color);
@@ -104,13 +99,25 @@ paper-menu a {
 }
 
 #paperToggle {
-  width: 45px;
-  height: 45px;
   border: none;
   color: var(--drawer-menu-color);
   background-color: transparent;
-  margin: -6px -6px 0px -6px;
   padding: 12px;
+  margin: 4px;
+  margin-left: -14px;
+}
+
+#mainToolbar .bottom {
+  padding-bottom: 120px;
+  margin-left: 36px;
+}
+
+#mainToolbar.has-shadow .appname {
+  font-size: 20px;
+  padding-bottom: 0px;
+  margin-left: 36px;
+}
+
 /* Height of the scroll area */
 .content {
   height: 700px;
@@ -121,9 +128,12 @@ paper-menu a {
 /* Small */
 
 @media (max-width: 600px) {
-
-  paper-toolbar.has-shadow {
-    height: 56px;
+  
+  paper-material {
+    --menu-container-display: none;
+    width: calc(97.33% - 32px);
+    padding-left: 16px;
+    padding-right: 16px;
   }
 
   .paper-font-display2 {
@@ -132,13 +142,6 @@ paper-menu a {
 
   .paper-font-display1 {
     font-size: 12px;
-  }
-
-  paper-material {
-    --menu-container-display: none;
-    width: calc(97.33% - 32px);
-    padding-left: 16px;
-    padding-right: 16px;
   }
 
   #drawer .paper-toolbar {
@@ -153,23 +156,6 @@ paper-menu a {
     background: white;
   }
 
-  #mainToolbar .bottom {
-    margin-left: 50px;
-    padding-bottom: 24px;
-  }
-
-  #mainToolbar.has-shadow .bottom {
-    padding-bottom: 0px;
-  }
-
-  .appname {
-    font-size: 20px;
-    padding-bottom: 0px;
-  }
-
-  #paperToggle {
-    margin-left: -14px;
-  }
 }
 
 @media (min-width: 601px) {
@@ -179,14 +165,6 @@ paper-menu a {
     padding-left: 30px;
     padding-right: 30px;
   }
-
-  #mainToolbar.has-shadow .bottom {
-    margin-left: 50px;
-    padding-bottom: 0;
-    padding-left: 0;
-    font-size: 24px;
-  }
-
 }
 
 /* Material Design Adaptive Breakpoints */

--- a/app/index.html
+++ b/app/index.html
@@ -117,7 +117,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 <p class="paper-font-body2">Looking for more Web App layouts? Check out our <a href="https://github.com/PolymerElements/app-layout-templates">layouts</a> collection. You can also <a href="http://polymerelements.github.io/app-layout-templates/">preview</a> them live.</p>
               </paper-material>
               <paper-material elevation="1">
-
                 <p class="paper-font-body2">This is another card.</p>
               </paper-material>
             </section>
@@ -147,8 +146,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             </section>
 
           </iron-pages>
-          </paper-header-panel>
-      </div>
+        </div>
+      </paper-header-panel>
     </paper-drawer-panel>
 
     <paper-toast id="caching-complete"

--- a/app/index.html
+++ b/app/index.html
@@ -85,6 +85,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           </paper-menu>
       </div>
       <paper-header-panel main mode="waterfall-tall">
+
         <!-- Main Toolbar -->
         <paper-toolbar id="mainToolbar">
           <button tabindex="1" id="paperToggle" paper-drawer-toggle>
@@ -103,6 +104,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         </paper-toolbar>
 
         <!-- Main Content -->
+        <div class="content">
           <iron-pages attr-for-selected="data-route" selected="{{route}}">
 
             <section data-route="home">
@@ -113,6 +115,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 <my-list></my-list>
 
                 <p class="paper-font-body2">Looking for more Web App layouts? Check out our <a href="https://github.com/PolymerElements/app-layout-templates">layouts</a> collection. You can also <a href="http://polymerelements.github.io/app-layout-templates/">preview</a> them live.</p>
+              </paper-material>
+              <paper-material elevation="1">
+
+                <p class="paper-font-body2">This is another card.</p>
               </paper-material>
             </section>
 
@@ -142,6 +148,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           </iron-pages>
           </paper-header-panel>
+      </div>
     </paper-drawer-panel>
 
     <paper-toast id="caching-complete"

--- a/app/index.html
+++ b/app/index.html
@@ -96,10 +96,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           <!-- Toolbar icons -->
           <paper-icon-button icon="refresh"></paper-icon-button>
           <paper-icon-button icon="search"></paper-icon-button>
-          <div class="middle"></div>
+          <div class="middle paper-font-display2 appname">Polymer Starter Kit</div>
 
           <!-- Application name -->
-          <div class="appname bottom paper-font-display2">Polymer Starter Kit</div>
+          <div class="bottom title"></div>
 
         </paper-toolbar>
 

--- a/app/index.html
+++ b/app/index.html
@@ -98,7 +98,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           <paper-icon-button icon="search"></paper-icon-button>
 
           <!-- Application name -->
-          <div class="middle paper-font-display2 appname">Polymer Starter Kit</div>
+          <div class="middle paper-font-display2 app-name">Polymer Starter Kit</div>
 
           <!-- Application sub title -->
           <div class="bottom title"></div>

--- a/app/index.html
+++ b/app/index.html
@@ -96,9 +96,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           <!-- Toolbar icons -->
           <paper-icon-button icon="refresh"></paper-icon-button>
           <paper-icon-button icon="search"></paper-icon-button>
-          <div class="middle paper-font-display2 appname">Polymer Starter Kit</div>
 
           <!-- Application name -->
+          <div class="middle paper-font-display2 appname">Polymer Starter Kit</div>
+
+          <!-- Application sub title -->
           <div class="bottom title"></div>
 
         </paper-toolbar>


### PR DESCRIPTION
reviewer: @chuckh (if you have time)

This set of changes attempts to update the hamburger menu (and application name) positioning to be closer to the Material spec.

Spec:

![](http://material-design.storage.googleapis.com/publish/material_v_4/material_ext_publish/0B6Okdz75tqQsLUFJUnFlRHVhUVU/layout_structure_appbar_metrics1.png)

Layout:

![screen shot 2015-06-07 at 00 48 32](https://cloud.githubusercontent.com/assets/110953/8021989/fb51f08e-0cae-11e5-9897-3c426d5777a5.png)

@kenchris is this closer to what you were after based on your reading of the spec? I think you were suggesting 20 was the right distance between the icon and title, however if it was 56px (your earlier number), that's easy enough to update to. 

![screen shot 2015-06-07 at 00 57 56](https://cloud.githubusercontent.com/assets/110953/8022011/48ccc5fe-0cb0-11e5-9adb-20d764da5d39.png)

It also includes several changes meant to improve the paper-header-panel/scroll behaviour of the layout, especially when there's more content than one card inside the page. 