### PR TITLE
move </dom-module> to bottom of file

### DIFF
--- a/app/elements/my-greeting/my-greeting.html
+++ b/app/elements/my-greeting/my-greeting.html
@@ -26,19 +26,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <!-- Listens for "input" event and sets greeting to <input>.value -->
     <input class="paper-font-body2" value="{{greeting::input}}">
   </template>
-</dom-module>
-<script>
-  (function() {
-    Polymer({
-      is: 'my-greeting',
 
-      properties: {
-        greeting: {
-          type: String,
-          value: 'Welcome!',
-          notify: true
+  <script>
+    (function() {
+      Polymer({
+        is: 'my-greeting',
+  
+        properties: {
+          greeting: {
+            type: String,
+            value: 'Welcome!',
+            notify: true
+          }
         }
-      }
-    });
-  })();
-</script>
+      });
+    })();
+  </script>
+
+</dom-module>

--- a/app/elements/my-list/my-list.html
+++ b/app/elements/my-list/my-list.html
@@ -21,27 +21,29 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </template>
     </ul>
   </template>
-</dom-module>
-<script>
-  (function () {
-    Polymer({
-      is: 'my-list',
-      properties: {
-        items: {
-          type: Array,
-          notify: true,
+  
+  <script>
+    (function () {
+      Polymer({
+        is: 'my-list',
+        properties: {
+          items: {
+            type: Array,
+            notify: true,
+          }
+        },
+        ready: function() {
+          this.items = [
+            'Responsive Web App boilerplate',
+            'Iron Elements and Paper Elements',
+            'End-to-end Build Tooling (including Vulcanize)',
+            'Unit testing with Web Component Tester',
+            'Routing with Page.js',
+            'Offline support with the Platinum Service Worker Elements'
+          ];
         }
-      },
-      ready: function() {
-        this.items = [
-          'Responsive Web App boilerplate',
-          'Iron Elements and Paper Elements',
-          'End-to-end Build Tooling (including Vulcanize)',
-          'Unit testing with Web Component Tester',
-          'Routing with Page.js',
-          'Offline support with the Platinum Service Worker Elements'
-        ];
-      }
-    });
-  })();
-</script>
+      });
+    })();
+  </script>
+
+</dom-module>


### PR DESCRIPTION
I moved the </dom-module> closing tag to the bottom, and adjusted indentation. Github's diff shows it as being crazy.

Per the code samples in the docs (many examples, one such: https://www.polymer-project.org/1.0/docs/start/quick-tour.html), it seems like the style that is being encouraged is to have the dom-module wrap everything, including the <script> tag. If this is good, the my-greeting should also be updated similarly. It's worth noting that before the change to "fix indentation" on this file, all that needed to change was move the dom-module down, as the indentation was already set up for it to be at the bottom.