### PR TITLE
Move own elements to the bottom of `elements.html`

### DIFF
--- a/app/elements/elements.html
+++ b/app/elements/elements.html
@@ -29,10 +29,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../bower_components/platinum-sw/platinum-sw-cache.html">
 <link rel="import" href="../bower_components/platinum-sw/platinum-sw-register.html">
 
+<!-- Configure your routes here -->
+<link rel="import" href="routing.html">
+
 <!-- Add your elements here -->
 <link rel="import" href="../styles/app-theme.html">
 <link rel="import" href="my-greeting/my-greeting.html">
 <link rel="import" href="my-list/my-list.html">
-
-<!-- Configure your routes here -->
-<link rel="import" href="routing.html">


### PR DESCRIPTION
This moves the `routes.html` to the bottom of the `elements.html` file so the Yeoman generator can easily add elements to the file.

cc @peterblazejewicz @robdodson 

Fixes https://github.com/yeoman/generator-polymer/issues/192