### PR TITLE
Remove two moot `.gitignore` entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
 node_modules
 dist
-test/temp
 bower_components
 .tmp
-test/bower_components/


### PR DESCRIPTION
We don't have a `test/` directory, only `app/test` so these two don't really make sense.