### PR TITLE
Remove confusing wording in `index.html`

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -17,7 +17,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="generator" content="Polymer Starter Kit" />
   <title>Polymer Starter Kit</title>
-  <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
+  <!-- Place favicon.ico and apple-touch-icon.png in the `app/` directory -->
 
   <!-- Chrome for Android theme color -->
   <meta name="theme-color" content="#303F9F">


### PR DESCRIPTION
The usage of the wording "root directory" there might be confusing to people that are totally new to tooling. They actually need to add the icons to `app/` not really to the root `/` of their project. WDYT?