### PR TITLE
Add a `logPrefix` to browserSync

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -181,6 +181,7 @@ gulp.task('clean', del.bind(null, ['.tmp', 'dist']));
 gulp.task('serve', ['styles', 'elements', 'images'], function () {
   browserSync({
     notify: false,
+    logPrefix: 'PSK',
     snippetOptions: {
       rule: {
         match: '<span id="browser-sync-binding"></span>',
@@ -212,6 +213,7 @@ gulp.task('serve', ['styles', 'elements', 'images'], function () {
 gulp.task('serve:dist', ['default'], function () {
   browserSync({
     notify: false,
+    logPrefix: 'PSK',
     snippetOptions: {
       rule: {
         match: '<span id="browser-sync-binding"></span>',


### PR DESCRIPTION
Ref https://github.com/PolymerElements/polymer-starter-kit/commit/a546ba23905889f0a4b95e650d72f8f9757ac237#commitcomment-11723846