### PR TITLE
Shorten `apple-mobile-web-app-title`

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -30,7 +30,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <!-- Add to homescreen for Chrome on Android -->
   <meta name="mobile-web-app-capable" content="yes">
-  <meta name="application-name" content="Polymer Starter Kit">
+  <meta name="application-name" content="PSK">
   <link rel="icon" sizes="192x192" href="images/touch/chrome-touch-icon-192x192.png">
 
   <!-- Add to homescreen for Safari on iOS -->


### PR DESCRIPTION
Current one was to long to be displayed well on most iPhones.

Fixes another part of #182