### PR TITLE
Remove redundant CSS height property. Closes #170

### DIFF
--- a/app/styles/app-theme.html
+++ b/app/styles/app-theme.html
@@ -51,7 +51,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     color: var(--secondary-text-color);
     background-color: var(--drawer-menu-color);
     border-bottom: var(--drawer-toolbar-border-color);
-    height: 64px;
   }
 
   paper-material {


### PR DESCRIPTION
This commit removes redundant height property declaration for
drawer paper toolbar component. Removing that property allows to
use documented classes to modify standard height.

After this commit the user would be able to use documented `tall` (or `medium-tall`) classes in application template to change `paper-toolbar` height.
Adding `tall` class:
```diff
          <!-- Drawer Toolbar -->
-        <paper-toolbar id="drawerToolbar">
+        <paper-toolbar id="drawerToolbar" class="tall">
           <span class="paper-font-title">Menu</span>
         </paper-toolbar>
```
- __before__ (no changes)
![20150617204213](https://cloud.githubusercontent.com/assets/14539/8215712/364ef250-1532-11e5-83ad-f971c39977d4.jpg)
- __after__ (expected change):
![20150617204146](https://cloud.githubusercontent.com/assets/14539/8215718/4a901988-1532-11e5-9704-af1227df110d.jpg)

Thanks!