### PR TITLE
Use `npm test` script to run `test:local` task

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
     "vulcanize": ">= 1.4.2",
     "web-component-tester": "^3.1.3"
   },
+  "scripts": {
+    "test": "gulp test:local"
+  },
   "engines": {
     "node": ">=0.10.0"
   }


### PR DESCRIPTION
Having to remember the specific command in every different project is difficult so why don't we alias `gulp test:local` to the `npm test` script? Doesn't add too much value but can't hurt eighter. Just saves me personally some seconds every time I have to run the suite.