### PR TITLE
Add support for connect-history-api-fallback

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,6 +20,7 @@ var merge = require('merge-stream');
 var path = require('path');
 var fs = require('fs');
 var glob = require('glob');
+var historyApiFallback = require('connect-history-api-fallback');
 
 var AUTOPREFIXER_BROWSERS = [
   'ie >= 10',
@@ -196,6 +197,7 @@ gulp.task('serve', ['styles', 'elements', 'images'], function () {
     // https: true,
     server: {
       baseDir: ['.tmp', 'app'],
+      middleware: [ historyApiFallback() ],
       routes: {
         '/bower_components': 'bower_components'
       }
@@ -226,7 +228,8 @@ gulp.task('serve:dist', ['default'], function () {
     // Note: this uses an unsigned certificate which on first access
     //       will present a certificate warning in the browser.
     // https: true,
-    server: 'dist'
+    server: 'dist',
+    middleware: [ historyApiFallback() ]
   });
 });
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "private": true,
   "devDependencies": {
     "browser-sync": "^2.7.7",
+    "connect-history-api-fallback": "^1.1.0",
     "del": "^1.1.1",
     "glob": "^5.0.6",
     "gulp": "^3.8.5",


### PR DESCRIPTION
Add middleware for proxying requests that improves our support for
‘hashbang: false’ and browsersync use across browser windows.

Adds https://github.com/PolymerElements/polymer-starter-kit/issues/201

Helps with #201 #66 

cc @MarkArts @teckays @fones 