### PR TITLE
Fix Gh-214. Merge precaches

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "devDependencies": {
+    "array-uniq": "^1.0.2",
     "browser-sync": "^2.7.7",
     "connect-history-api-fallback": "^1.1.0",
     "del": "^1.1.1",


### PR DESCRIPTION
This allows the user to write files in their `app/precache.json` and have those merged with the file generated at `dist/precache.json`. This is useful for not having to go into the gulpfile to add files you want to precache.

Originally I ran into this issue when I added files to `precache.json` and ran `gulp serve` but was surprised when I generated a `dist` build and my files were no longer caching.