### PR TITLE
Update to latest gulp

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "connect-history-api-fallback": "^1.1.0",
     "del": "^1.1.1",
     "glob": "^5.0.6",
-    "gulp": "^3.8.5",
+    "gulp": "^3.9.0",
     "gulp-autoprefixer": "^2.1.0",
     "gulp-cache": "^0.2.8",
     "gulp-changed": "^1.0.0",


### PR DESCRIPTION
I started getting mismatch warnings today.

```
[19:46:59] Warning: gulp version mismatch:
[19:46:59] Global gulp is 3.9.0
[19:46:59] Local gulp is 3.8.11
```

If there's a reason to hold off on upgrading I'm cool with that. I didn't see a changelog in the gulp releases page so I'm not really sure the difference between 3.8 and 3.9 :\