### PR TITLE
Migrate to paper-scroll-header-panel (closes #206 and #175)

### DIFF
--- a/app/elements/elements.html
+++ b/app/elements/elements.html
@@ -16,11 +16,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <!-- Paper elements -->
 <link rel="import" href="../bower_components/paper-drawer-panel/paper-drawer-panel.html">
-<link rel="import" href="../bower_components/paper-header-panel/paper-header-panel.html">
 <link rel="import" href="../bower_components/paper-icon-button/paper-icon-button.html">
 <link rel="import" href="../bower_components/paper-item/paper-item.html">
 <link rel="import" href="../bower_components/paper-material/paper-material.html">
 <link rel="import" href="../bower_components/paper-menu/paper-menu.html">
+<link rel="import" href="../bower_components/paper-scroll-header-panel/paper-scroll-header-panel.html">
 <link rel="import" href="../bower_components/paper-styles/paper-styles-classes.html">
 <link rel="import" href="../bower_components/paper-toast/paper-toast.html">
 <link rel="import" href="../bower_components/paper-toolbar/paper-toolbar.html">

--- a/app/index.html
+++ b/app/index.html
@@ -175,7 +175,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           </iron-pages>
         </div>
-      </paper-header-panel>
+      </paper-scroll-header-panel>
     </paper-drawer-panel>
 
     <!-- Uncomment next block to enable Service Worker support (1/2) -->

--- a/app/index.html
+++ b/app/index.html
@@ -60,7 +60,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <template is="dom-bind" id="app">
 
     <paper-drawer-panel id="paperDrawerPanel">
-      <paper-header-panel drawer mode="seam">
+      <!-- Drawer Scroll Header Panel -->
+      <paper-scroll-header-panel drawer fixed>
 
         <!-- Drawer Toolbar -->
         <paper-toolbar id="drawerToolbar">
@@ -84,11 +85,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             <span>Contact</span>
           </a>
         </paper-menu>
-      </paper-header-panel>
-      <paper-header-panel main mode="waterfall-tall">
+      </paper-scroll-header-panel>
+
+      <!-- Main Area -->
+      <paper-scroll-header-panel main condenses keep-condensed-header>
 
         <!-- Main Toolbar -->
-        <paper-toolbar id="mainToolbar">
+        <paper-toolbar id="mainToolbar" class="tall">
           <paper-icon-button id="paperToggle" icon="menu" paper-drawer-toggle></paper-icon-button>
           <span class="flex"></span>
 
@@ -97,10 +100,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           <paper-icon-button icon="search"></paper-icon-button>
 
           <!-- Application name -->
-          <div class="middle paper-font-display2 app-name">Polymer Starter Kit</div>
+          <div class="middle middle-container center horizontal layout">
+            <div class="app-name">Polymer Starter Kit</div>
+          </div>
 
           <!-- Application sub title -->
-          <div class="bottom title"></div>
+          <div class="bottom bottom-container center horizontal layout">
+            <div class="bottom-title paper-font-subhead">The future of the web today</div>
+          </div>
 
         </paper-toolbar>
 

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -40,7 +40,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     var yRatio = Math.min(1, detail.y / heightDiff);
     var scaleMiddle = Math.max(0.50, (heightDiff - detail.y) / (heightDiff / 0.50)  + 0.50);
     var scaleBottom = 1 - yRatio;
-    console.log("heightDiff: ",heightDiff, "yRatio:",yRatio, "detail.y", detail.y);
 
     // Move/translate middleContainer
     Polymer.Base.transform('translate3d(0,' + yRatio * 100 + '%,0)', middleContainer);

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -30,7 +30,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     // imports are loaded and elements have been registered
   });
 
-  // Custom transformation: scale header's titles
+  // Main area's paper-scroll-header-panel custom condensing transformation of
+  // the appName in the middle-container and the bottom title in the bottom-container.
+  // The appName is moved to top and shrunk on condensing. The bottom sub title
+  // is shrunk to nothing on condensing.
   addEventListener('paper-header-transform', function(e) {
     var appName = document.querySelector('.app-name');
     var middleContainer = document.querySelector('.middle-container');
@@ -38,7 +41,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     var detail = e.detail;
     var heightDiff = detail.height - detail.condensedHeight;
     var yRatio = Math.min(1, detail.y / heightDiff);
-    var scaleMiddle = Math.max(0.50, (heightDiff - detail.y) / (heightDiff / 0.50)  + 0.50);
+    var maxMiddleScale = 0.50;  // appName max size when condensed. The smaller the number the smaller the condensed size.
+    var scaleMiddle = Math.max(maxMiddleScale, (heightDiff - detail.y) / (heightDiff / (1-maxMiddleScale))  + maxMiddleScale);
     var scaleBottom = 1 - yRatio;
 
     // Move/translate middleContainer
@@ -47,7 +51,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     // Scale bottomContainer and bottom sub title to nothing and back
     Polymer.Base.transform('scale(' + scaleBottom + ') translateZ(0)', bottomContainer);
 
-    // Scale middle app name
+    // Scale middleContainer appName
     Polymer.Base.transform('scale(' + scaleMiddle + ') translateZ(0)', appName);
   });
 

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -30,24 +30,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     // imports are loaded and elements have been registered
   });
 
-  // custom transformation: scale header's titles
+  // Custom transformation: scale header's titles
   addEventListener('paper-header-transform', function(e) {
     var appName = document.querySelector('.app-name');
     var middleContainer = document.querySelector('.middle-container');
     var bottomContainer = document.querySelector('.bottom-container');
-    var d = e.detail;
-    var m = d.height - d.condensedHeight;
-    var y = Math.min(1, d.y / m);
-    var scaleMiddle = Math.max(0.50, (m - d.y) / (m / 0.50)  + 0.50);
-    var scaleBottom = 1 - y;
+    var detail = e.detail;
+    var heightDiff = detail.height - detail.condensedHeight;
+    var yRatio = Math.min(1, detail.y / heightDiff);
+    var scaleMiddle = Math.max(0.50, (heightDiff - detail.y) / (heightDiff / 0.50)  + 0.50);
+    var scaleBottom = 1 - yRatio;
+    console.log("heightDiff: ",heightDiff, "yRatio:",yRatio, "detail.y", detail.y);
 
-    // move/translate middleContainer
-    Polymer.Base.transform('translate3d(0,' + y * 100 + '%,0)', middleContainer);
+    // Move/translate middleContainer
+    Polymer.Base.transform('translate3d(0,' + yRatio * 100 + '%,0)', middleContainer);
 
-    // scale bottomContainer and bottom sub title to nothing and back
+    // Scale bottomContainer and bottom sub title to nothing and back
     Polymer.Base.transform('scale(' + scaleBottom + ') translateZ(0)', bottomContainer);
 
-    // scale middle app name
+    // Scale middle app name
     Polymer.Base.transform('scale(' + scaleMiddle + ') translateZ(0)', appName);
   });
 

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -30,6 +30,27 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     // imports are loaded and elements have been registered
   });
 
+  // custom transformation: scale header's titles
+  addEventListener('paper-header-transform', function(e) {
+    var appName = document.querySelector('.app-name');
+    var middleContainer = document.querySelector('.middle-container');
+    var bottomContainer = document.querySelector('.bottom-container');
+    var d = e.detail;
+    var m = d.height - d.condensedHeight;
+    var y = Math.min(1, d.y / m);
+    var scaleMiddle = Math.max(0.50, (m - d.y) / (m / 0.50)  + 0.50);
+    var scaleBottom = 1 - y;
+
+    // move/translate middleContainer
+    Polymer.Base.transform('translate3d(0,' + y * 100 + '%,0)', middleContainer);
+
+    // scale bottomContainer and bottom sub title to nothing and back
+    Polymer.Base.transform('scale(' + scaleBottom + ') translateZ(0)', bottomContainer);
+
+    // scale middle app name
+    Polymer.Base.transform('scale(' + scaleMiddle + ') translateZ(0)', appName);
+  });
+
   // Close drawer after menu item is selected if drawerPanel is narrow
   app.onMenuSelect = function() {
     var drawerPanel = document.querySelector('#paperDrawerPanel');

--- a/app/styles/app-theme.html
+++ b/app/styles/app-theme.html
@@ -100,6 +100,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   paper-toolbar.tall .app-name {
     font-size: 40px;
     font-weight: 300;
+    /* Required for main area's paper-scroll-header-panel custom condensing transformation */
     -webkit-transform-origin: left center;
     transform-origin: left center;
   }
@@ -116,6 +117,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   #mainToolbar .bottom {
     margin-left: 48px;
+    /* Required for main area's paper-scroll-header-panel custom condensing transformation */
     -webkit-transform-origin: left center;
     transform-origin: left center;
   }

--- a/app/styles/app-theme.html
+++ b/app/styles/app-theme.html
@@ -53,6 +53,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     border-bottom: var(--drawer-toolbar-border-color);
   }
 
+  paper-scroll-header-panel {
+    height: 100%;
+  }
+
   paper-material {
     border-radius: 2px;
     height: 100%;
@@ -93,24 +97,27 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     padding: 0 16px;
   }
 
-  #mainToolbar .middle {
+  paper-toolbar.tall .app-name {
+    font-size: 40px;
+    font-weight: 300;
+    -webkit-transform-origin: left center;
+    transform-origin: left center;
+  }
+
+  #mainToolbar .middle-container  {
+    height: 100%;
     margin-left: 48px;
   }
 
   #mainToolbar:not(.tall) .middle {
-    font-size: 20px;
+    font-size: 18px;
     padding-bottom: 0;
-    margin-left: 48px;
   }
 
   #mainToolbar .bottom {
-    transition: 0.18s opacity 0.18s ease-in;
-    opacity: 1;
-  }
-
-  #mainToolbar:not(.tall) .bottom {
-    transition: 0.18s opacity ease-in;
-    opacity: 0;
+    margin-left: 48px;
+    -webkit-transform-origin: left center;
+    transform-origin: left center;
   }
 
   /* Height of the scroll area */
@@ -134,8 +141,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       font-size: 12px;
     }
 
-    .app-name {
-      font-size: 26px;
+    paper-toolbar.tall .app-name {
+      font-size: 24px;
+      font-weight: 400;
     }
 
     #drawer .paper-toolbar {


### PR DESCRIPTION
Migrate from paper-header-panel to paper-scroll-header-panel. Both middle and bottom titles condense correctly.

Closes #206 and #175.

![psk-paper-scroll-header-panel](https://cloud.githubusercontent.com/assets/19915/8477215/548b6b3a-207d-11e5-8dc6-57f7f004772a.gif)
