### PR TITLE
enhance routing

### DIFF
--- a/app/elements/routing.html
+++ b/app/elements/routing.html
@@ -40,6 +40,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       app.route = 'contact';
     });
 
+    page('*', function() {
+      app.$.toast.text = "Can't find: " + window.location.href  + ". Redirected you to Home Page";
+      app.$.toast.show();
+      page.redirect('/');
+    });
+
     // add #! before urls
     page({
       hashbang: true

--- a/app/index.html
+++ b/app/index.html
@@ -92,7 +92,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </paper-scroll-header-panel>
 
       <!-- Main Area -->
-      <paper-scroll-header-panel main condenses keep-condensed-header>
+      <paper-scroll-header-panel main id="headerPanelMain" condenses keep-condensed-header>
 
         <!-- Main Toolbar -->
         <paper-toolbar id="mainToolbar" class="tall">
@@ -181,6 +181,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         </div>
       </paper-scroll-header-panel>
     </paper-drawer-panel>
+
+    <paper-toast id="toast">
+      <span class="toast-hide-button" role="button" tabindex="0" onclick="app.$.toast.hide()">Ok</span>
+    </paper-toast>
 
     <!-- Uncomment next block to enable Service Worker support (1/2) -->
     <!--

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -68,7 +68,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   // Scroll page to top and expand header
   app.scrollPageToTop = function() {
-    document.getElementById('mainContainer').scrollTop = 0;
+    app.$.headerPanelMain.scrollToTop(true);
   };
 
 })(document);

--- a/app/styles/app-theme.html
+++ b/app/styles/app-theme.html
@@ -127,6 +127,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     height: 900px;
   }
 
+  #toast .toast-hide-button {
+    color: #eeff41;
+    margin: 10px;
+  }
+
   /* Breakpoints */
 
   /* Small */


### PR DESCRIPTION
1- adds redirect to home when no path is matched (`page.redirect`)
2- removes redundant app.route value assignment

` app.route` is set twice when a menu item is clicked: 
* first by binding to `paper-menu`'s `selected` property
* second within the routing logic (where it should be)

3- resets main `paper-scroll-header-panel` scroll after route change (current behaviors is to leave scroll as is)

before changes:
![before changes](https://cloud.githubusercontent.com/assets/2822146/8632662/c3928934-279c-11e5-9bad-61a0080c0011.gif)

after changes:
![after changes](https://cloud.githubusercontent.com/assets/2822146/8632664/ce7c68b0-279c-11e5-92e6-bf7491586f1e.gif)




