### PR TITLE
Reduced dist size

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -232,6 +232,15 @@ gulp.task('serve:dist', ['default'], function () {
   });
 });
 
+// Removes unneeded bower files from dist
+// Note: bower_components are needed for vulcanize which is called before
+gulp.task('stripDist', del.bind(null, [
+  'dist/bower_components/*/',
+  '!dist/bower_components/webcomponentsjs/',
+  'dist/bower_components/webcomponentsjs/*',
+  '!dist/bower_components/webcomponentsjs/webcomponents-lite.min.js'
+]));
+
 // Build Production Files, the Default Task
 gulp.task('default', ['clean'], function (cb) {
   runSequence(
@@ -239,6 +248,7 @@ gulp.task('default', ['clean'], function (cb) {
     'elements',
     ['jshint', 'images', 'fonts', 'html'],
     'vulcanize',
+    'stripDist',
     cb);
     // Note: add , 'precache' , after 'vulcanize', if your are going to use Service Worker
 });


### PR DESCRIPTION
Makes dist lighter by removing all bower components except the webcomponents-lite.js file

Before:
```
$ du -sh dist/bower_components
 11M    dist/bower_components
```
After:
```
$ du -sh dist/bower_components
 40K    dist/bower_components
```