### PR TITLE
fix routing.html page callbacks not called in iOS

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -69,18 +69,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         </paper-toolbar>
 
         <!-- Drawer Content -->
-        <paper-menu class="list" attr-for-selected="data-route" selected="{{route}}" on-iron-select="onMenuSelect">
-          <a data-route="home" href="/">
+        <paper-menu class="list" attr-for-selected="data-route" selected="[[route]]" on-iron-select="onMenuSelect">
+          <a data-route="home" href="javascript:void(0)" path="/">
             <iron-icon icon="home"></iron-icon>
             <span>Home</span>
           </a>
 
-          <a data-route="users" href="/users">
+          <a data-route="users" href="javascript:void(0)" path="/users">
             <iron-icon icon="info"></iron-icon>
             <span>Users</span>
           </a>
 
-          <a data-route="contact" href="/contact">
+          <a data-route="contact" href="javascript:void(0)" path="/contact">
             <iron-icon icon="mail"></iron-icon>
             <span>Contact</span>
           </a>

--- a/app/index.html
+++ b/app/index.html
@@ -70,17 +70,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         <!-- Drawer Content -->
         <paper-menu class="list" attr-for-selected="data-route" selected="[[route]]">
-          <a data-route="home" href="/" on-click="onMenuSelect">
+          <a data-route="home" href="/" on-click="onDataRouteClick">
             <iron-icon icon="home"></iron-icon>
             <span>Home</span>
           </a>
 
-          <a data-route="users" href="/users" on-click="onMenuSelect">
+          <a data-route="users" href="/users" on-click="onDataRouteClick">
             <iron-icon icon="info"></iron-icon>
             <span>Users</span>
           </a>
 
-          <a data-route="contact" href="/contact" on-click="onMenuSelect">
+          <a data-route="contact" href="/contact" on-click="onDataRouteClick">
             <iron-icon icon="mail"></iron-icon>
             <span>Contact</span>
           </a>

--- a/app/index.html
+++ b/app/index.html
@@ -69,18 +69,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         </paper-toolbar>
 
         <!-- Drawer Content -->
-        <paper-menu class="list" attr-for-selected="data-route" selected="[[route]]" on-iron-select="onMenuSelect">
-          <a data-route="home" href="javascript:void(0)" path="/">
+        <paper-menu class="list" attr-for-selected="data-route" selected="[[route]]">
+          <a data-route="home" href="/" on-click="onMenuSelect">
             <iron-icon icon="home"></iron-icon>
             <span>Home</span>
           </a>
 
-          <a data-route="users" href="javascript:void(0)" path="/users">
+          <a data-route="users" href="/users" on-click="onMenuSelect">
             <iron-icon icon="info"></iron-icon>
             <span>Users</span>
           </a>
 
-          <a data-route="contact" href="javascript:void(0)" path="/contact">
+          <a data-route="contact" href="/contact" on-click="onMenuSelect">
             <iron-icon icon="mail"></iron-icon>
             <span>Contact</span>
           </a>

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -56,10 +56,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   });
 
   // Close drawer after menu item is selected if drawerPanel is narrow
-  app.onMenuSelect = function() {
+  app.onMenuSelect = function(event) {
     var drawerPanel = document.querySelector('#paperDrawerPanel');
     if (drawerPanel.narrow) {
       drawerPanel.closeDrawer();
+    }
+
+    var attributes = event.detail.item.attributes;
+    var path = attributes.path.value;
+    var route = attributes['data-route'].value;
+    if (route !== app.route) {
+      page(path);
     }
   };
 

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -56,17 +56,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   });
 
   // Close drawer after menu item is selected if drawerPanel is narrow
-  app.onMenuSelect = function(event) {
+  app.onMenuSelect = function() {
     var drawerPanel = document.querySelector('#paperDrawerPanel');
     if (drawerPanel.narrow) {
       drawerPanel.closeDrawer();
-    }
-
-    var attributes = event.detail.item.attributes;
-    var path = attributes.path.value;
-    var route = attributes['data-route'].value;
-    if (route !== app.route) {
-      page(path);
     }
   };
 

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -56,7 +56,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   });
 
   // Close drawer after menu item is selected if drawerPanel is narrow
-  app.onMenuSelect = function() {
+  app.onDataRouteClick = function() {
     var drawerPanel = document.querySelector('#paperDrawerPanel');
     if (drawerPanel.narrow) {
       drawerPanel.closeDrawer();


### PR DESCRIPTION
fix for #237 

Needed to change the flow that comes before page.js callbacks

- before fix
`<a href="/pathForPage">` invokes page.js, but also invokes app.onMenuSelect() at the same time.

- after fix
`<a href="javascript:void(0)" path="/pathForPage">` invokes only app.onMenuSelect(event), and the corresponding page.js callback is called inside onMenuSelect.
Also changed `{{route}}` to `[[route]]` on the paper-menu (also included in PR #247)

