### PR TITLE
#260 : Prevent the main panel's condensing effect from breaking when reusing the 'app-name', 'middle-container' or 'bottom-container' class

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -35,9 +35,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   // The appName is moved to top and shrunk on condensing. The bottom sub title
   // is shrunk to nothing on condensing.
   addEventListener('paper-header-transform', function(e) {
-    var appName = document.querySelector('.app-name');
-    var middleContainer = document.querySelector('.middle-container');
-    var bottomContainer = document.querySelector('.bottom-container');
+    var appName = document.querySelector('#mainToolbar .app-name');
+    var middleContainer = document.querySelector('#mainToolbar .middle-container');
+    var bottomContainer = document.querySelector('#mainToolbar .bottom-container');
     var detail = e.detail;
     var heightDiff = detail.height - detail.condensedHeight;
     var yRatio = Math.min(1, detail.y / heightDiff);


### PR DESCRIPTION
#260 : Prevent the main panel's condensing effect from breaking when reusing the 'app-name', 'middle-container' or 'bottom-container' class