### PR TITLE
Added typescript 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 dist
 bower_components
 .tmp
+app/scripts/*.js
+!app/scripts/app.js

--- a/app/elements/my-greeting/my-greeting.html
+++ b/app/elements/my-greeting/my-greeting.html
@@ -26,21 +26,4 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <!-- Listens for "input" event and sets greeting to <input>.value -->
     <input class="paper-font-body2" value="{{greeting::input}}">
   </template>
-
-  <script>
-    (function() {
-      Polymer({
-        is: 'my-greeting',
-
-        properties: {
-          greeting: {
-            type: String,
-            value: 'Welcome!',
-            notify: true
-          }
-        }
-      });
-    })();
-  </script>
-
 </dom-module>

--- a/app/index.html
+++ b/app/index.html
@@ -49,7 +49,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <!-- build:js bower_components/webcomponentsjs/webcomponents-lite.min.js -->
   <script src="bower_components/webcomponentsjs/webcomponents-lite.js"></script>
   <!-- endbuild -->
-
+  
   <!-- will be replaced with elements/elements.vulcanized.html -->
   <link rel="import" href="elements/elements.html">
   <!-- endreplace-->
@@ -199,6 +199,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <!-- build:js scripts/app.js -->
   <script src="scripts/app.js"></script>
+  <script src="scripts/polymer-ts.js"></script>
+  <script src="scripts/my-greeting.js"></script>
   <!-- endbuild-->
 </body>
 

--- a/app/scripts-ts/my-greeting.ts
+++ b/app/scripts-ts/my-greeting.ts
@@ -1,0 +1,21 @@
+@component("my-greeting")
+class MyGreeting extends polymer.Base {
+   @property({notify: true})
+   greeting:string = "Welcome!";
+}
+MyGreeting.register();
+
+/*************************
+(function() {
+  Polymer({
+    is: 'my-greeting',
+    properties: {
+      greeting: {
+        type: String,
+        value: 'Welcome!',
+        notify: true
+      }
+    }
+  });
+})();
+*************************/

--- a/app/test/my-greeting-basic.html
+++ b/app/test/my-greeting-basic.html
@@ -22,7 +22,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <!-- Import the element to test -->
   <link rel="import" href="../elements/my-greeting/my-greeting.html">
-
+  
 </head>
 <body>
 
@@ -31,6 +31,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <my-greeting></my-greeting>
     </template>
   </test-fixture>
+  
+  <script src="../scripts/polymer-ts.js"></script>
+  <script src="../scripts/my-greeting.js"></script>
 
   <script>
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -58,7 +58,7 @@ gulp.task('elements', function () {
 // Lint JavaScript
 gulp.task('jshint', function () {
   return gulp.src([
-      'app/scripts/**/*.js',
+      //'app/scripts/**/*.js',
       'app/elements/**/*.js',
       'app/elements/**/*.html'
     ])
@@ -84,6 +84,7 @@ gulp.task('images', function () {
 gulp.task('copy', function () {
   var app = gulp.src([
     'app/*',
+    '!app/scripts-ts',
     '!app/test',
     '!app/precache.json'
   ], {
@@ -178,7 +179,7 @@ gulp.task('precache', function (callback) {
 gulp.task('clean', del.bind(null, ['.tmp', 'dist']));
 
 // Watch Files For Changes & Reload
-gulp.task('serve', ['styles', 'elements', 'images'], function () {
+gulp.task('serve', ['ts', 'styles', 'elements', 'images'], function () {
   browserSync({
     notify: false,
     logPrefix: 'PSK',
@@ -207,6 +208,7 @@ gulp.task('serve', ['styles', 'elements', 'images'], function () {
   gulp.watch(['app/styles/**/*.css'], ['styles', reload]);
   gulp.watch(['app/elements/**/*.css'], ['elements', reload]);
   gulp.watch(['app/{scripts,elements}/**/*.js'], ['jshint']);
+  gulp.watch(['app/scripts-ts/**/*.ts'], ['ts']);
   gulp.watch(['app/images/**/*'], reload);
 });
 
@@ -233,7 +235,7 @@ gulp.task('serve:dist', ['default'], function () {
 });
 
 // Build Production Files, the Default Task
-gulp.task('default', ['clean'], function (cb) {
+gulp.task('default', ['ts', 'clean'], function (cb) {
   runSequence(
     ['copy', 'styles'],
     'elements',
@@ -249,3 +251,10 @@ require('web-component-tester').gulp.init(gulp);
 
 // Load custom tasks from the `tasks` directory
 try { require('require-dir')('tasks'); } catch (err) {}
+
+var tsProject = $.typescript.createProject('tsconfig.json');
+gulp.task('ts', function() {
+    var tsResult = gulp.src(['app/scripts-ts/*.ts', 'bower_components/polymer-ts/polymer-ts.ts'])
+        .pipe($.typescript(tsProject));
+    return tsResult.js.pipe(gulp.dest('app/scripts'));
+});

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "require-dir": "^0.3.0",
     "run-sequence": "^1.0.2",
     "vulcanize": ">= 1.4.2",
-    "web-component-tester": "^3.1.3"
+    "web-component-tester": "^3.1.3",
+    "typescript": "^1.5.0",
+    "gulp-typescript": "^2.8.0"
   },
   "scripts": {
     "test": "gulp test:local",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,7 @@
+{
+    "compilerOptions": {
+        "target": "es5",
+        "sourceMap": false,
+        "experimentalDecorators": true
+    }
+}


### PR DESCRIPTION
You can use both type script and js script at the same time without extra build steps `gulp serve:dist`
Unlocks all features like in dept smart auto complete, type safety, definition look ups, and many many more of the visual code editor. ES6 apps right now that works in any browser.

```js
@component("my-greeting")
class MyGreeting extends polymer.Base {
   @property({notify: true}) 
   greeting:string = "Welcome!";
}
MyGreeting.register();
```
equals
```js
(function() {
  Polymer({
    is: 'my-greeting',
    properties: {
      greeting: {
        type: String,
        value: 'Welcome!',
        notify: true
      }
    }
  });
})();
```
Both will work, you can mix as much ts or non ts elements as you want.