### PR TITLE
Gulpfile: add callback to `clean` task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -175,7 +175,9 @@ gulp.task('precache', function (callback) {
 });
 
 // Clean Output Directory
-gulp.task('clean', del.bind(null, ['.tmp', 'dist']));
+gulp.task('clean', function (cb) {
+  del(['.tmp', 'dist'], cb);
+});
 
 // Watch Files For Changes & Reload
 gulp.task('serve', ['styles', 'elements', 'images'], function () {


### PR DESCRIPTION
To let Gulp know when deletion of the folders is finished. This change recently happened in WSK as well: https://github.com/google/web-starter-kit/commit/6b4df236544cba9f115c731db721c8e865d5c6ad