### PR TITLE
removed broken reference for bower_components/page/page.js

### DIFF
--- a/app/elements/routing.html
+++ b/app/elements/routing.html
@@ -8,7 +8,7 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 
-<script src="../../bower_components/page/page.js"></script>
+<script src="../bower_components/page/page.js"></script>
 <script>
   window.addEventListener('WebComponentsReady', function() {
 


### PR DESCRIPTION
The reference to the  bower_components/page/page.js was broken. It did not serve the component from the same route as the other bower_components.