### PR TITLE
✋ npm and global module gulp work 👷

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ This installs the element sets (Paper, Iron, Platinum) and tools the starter kit
 #### Serve / watch
 
 ```sh
-gulp serve
+npm run start
 ```
 
 This outputs an IP address you can use to locally test and another that can be used on devices connected to your network.
@@ -87,7 +87,7 @@ This outputs an IP address you can use to locally test and another that can be u
 #### Run tests
 
 ```sh
-gulp test:local
+npm test
 ```
 
 This runs the unit tests defined in the `app/test` directory through [web-component-tester](https://github.com/Polymer/web-component-tester).

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The standard version of Polymer Starter Kit comes with tools that are very handy
 With Node.js installed, run the following one liner from the root of your Polymer Starter Kit download:
 
 ```sh
-npm install -g gulp bower && npm install && bower install
+npm install -g bower && npm install && bower install
 ```
 
 #### Prerequisites (for everyone)
@@ -43,7 +43,6 @@ The full starter kit requires the following major dependencies:
 
 - Node.js, used to run JavaScript tools from the command line.
 - npm, the node package manager, installed with Node.js and used to install Node.js packages.
-- gulp, a Node.js-based build tool.
 - bower, a Node.js-based package manager used to install front-end packages (like Polymer).
 
 **To install dependencies:**
@@ -58,13 +57,13 @@ The version should be at or above 0.12.x.
 
 2)  If you don't have Node.js installed, or you have a lower version, go to [nodejs.org](https://nodejs.org) and click on the big green Install button.
 
-3)  Install `gulp` and `bower` globally.
+3)  Install `bower` globally.
 
 ```sh
-npm install -g gulp bower
+npm install -g bower
 ```
 
-This lets you run `gulp` and `bower` from the command line.
+This lets you run `bower` from the command line.
 
 4)  Install the starter kit's local `npm` and `bower` dependencies.
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ This runs the unit tests defined in the `app/test` directory through [web-compon
 #### Build & Vulcanize
 
 ```sh
-gulp
+npm run build
 ```
 
 Build and optimize the current project, ready for deployment. This includes linting as well as vulcanization, image, script, stylesheet and HTML optimization and minification.

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   },
   "scripts": {
     "test": "gulp test:local",
-    "start": "gulp serve"
+    "start": "gulp serve",
+    "build": "gulp"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
### What?

* Add npm cli is pretty awesome https://docs.npmjs.com/cli/run-script ... aliasing local package installs as npm commands is :cool: too.
* Since we only reference gulp via npm commands, people do not need to install gulp globally. :book: 

### Why?

Global modules can be problematic especially for users working on multiple projects with multiple versions of node and or gulp. This lets us not add to the community debt :bank: .

----

Let me know if this is no good, or a terrible idea, we can kill it :skull: no hard feelings :sparkling_heart: 

Thanks!!! :+1: :clap: :palm_tree: 