### PR TITLE
Update dependency for Polymer 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ gulp test:local
 
 This runs the unit tests defined in the `app/test` directory through [web-component-tester](https://github.com/Polymer/web-component-tester).
 
+To run tests Java 7 or higher is required.
+
 #### Build & Vulcanize
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ gulp test:local
 
 This runs the unit tests defined in the `app/test` directory through [web-component-tester](https://github.com/Polymer/web-component-tester).
 
-To run tests Java 7 or higher is required.
+To run tests Java 7 or higher is required. To update Java go to http://www.oracle.com/technetwork/java/javase/downloads/index.html and download ***JDK*** and install it.
 
 #### Build & Vulcanize
 

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "polymer-starter-kit",
   "private": true,
   "dependencies": {
-    "polymer": "Polymer/polymer#^1.1.0"
+    "polymer": "Polymer/polymer#^1.1.0",
     "iron-elements": "PolymerElements/iron-elements#^1.0.0",
     "paper-elements": "PolymerElements/paper-elements#^1.0.1",
     "platinum-elements": "PolymerElements/platinum-elements#^1.1.0",

--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,7 @@
   "name": "polymer-starter-kit",
   "private": true,
   "dependencies": {
+    "polymer": "Polymer/polymer#^1.1.0"
     "iron-elements": "PolymerElements/iron-elements#^1.0.0",
     "paper-elements": "PolymerElements/paper-elements#^1.0.1",
     "platinum-elements": "PolymerElements/platinum-elements#^1.1.0",


### PR DESCRIPTION
This is required for Polymer 1.1.0 to install. Also for Selenium to
work when running gulp test:local you have to update to Java 7 or
later. Updates readme.md for requirement.

@addyosmani please review. 