### PR TITLE
Remove an accidentally added word

### DIFF
--- a/app/elements/my-greeting/my-greeting.html
+++ b/app/elements/my-greeting/my-greeting.html
@@ -48,4 +48,3 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </script>
 
 </dom-module>
-greeting


### PR DESCRIPTION
This looked like unused and added by accident in https://github.com/PolymerElements/polymer-starter-kit/commit/98a7e3c37f824386b8b0028d6fb3014df0844f90.