### PR TITLE
Add starter element and gulp task el

### DIFF
--- a/app/elements/starter-element.html
+++ b/app/elements/starter-element.html
@@ -1,0 +1,40 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<dom-module id="starter-element">
+  <template>
+    <style include="shared-styles"></style>
+    <style>
+      :host {
+        display: block;
+      }
+    </style>
+    <paper-material elevation="1">
+      <h2 class="page-title">Welecome to <span>{{name}}</span>!</h2>
+      <p>This is your new element <span>{{name}}</span>.</p>
+    </paper-material>
+  </template>
+
+  <script>
+    (function() {
+      Polymer({
+        is: 'starter-element',
+
+        properties: {
+          name: {
+            type: String,
+            value: 'starter-element'
+          }
+        }
+      });
+    })();
+  </script>
+
+</dom-module>

--- a/gulp-tasks/el.js
+++ b/gulp-tasks/el.js
@@ -1,0 +1,24 @@
+'use strict';
+
+// Create new element from app/elements/starter-element.html
+// syntax: gulp el --new my-element
+module.exports = function ($, gulp, parseArgs, replace, fs) { return function () {
+  var newName = parseArgs(process.argv.slice(2)).new;
+  if (!fs.existsSync('app/elements/' + newName)){
+    if ( newName !== undefined && newName !== true && newName.indexOf("-") > 0) {
+      var folder = 'app/elements/' + newName;
+      var newFile = newName + '.html';
+      gulp.src('app/elements/starter-element.html')
+        .pipe($.rename(newFile))
+        .pipe(replace('starter-element', newName))
+        .pipe(gulp.dest(folder));
+      console.log('el - created: ', folder + '/' + newFile);
+      console.log('el - note: add import to elements.html for ' + newFile );
+    } else {
+      console.log('el - Bad new element name: ', newName);
+      console.log('el - correct syntax: gulp el --new my-element');
+    }
+  } else {
+    console.log('el - folder exits, use different name: ',newName);
+  }
+};};

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -24,6 +24,9 @@ var historyApiFallback = require('connect-history-api-fallback');
 var packageJson = require('./package.json');
 var crypto = require('crypto');
 var polybuild = require('polybuild');
+var parseArgs = require('minimist')
+var replace = require('gulp-replace');
+var taskDir = './gulp-tasks/';
 
 var AUTOPREFIXER_BROWSERS = [
   'ie >= 10',
@@ -202,6 +205,10 @@ gulp.task('cache-config', function (callback) {
 gulp.task('clean', function (cb) {
   del(['.tmp', 'dist'], cb);
 });
+
+// Create new element from app/elements/starter-element.html
+// syntax: gulp el --new my-element
+gulp.task('el', require(taskDir + 'el')($, gulp, parseArgs, replace, fs));
 
 // Watch files for changes & reload
 gulp.task('serve', ['styles', 'elements', 'images'], function () {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "gulp-vulcanize": "^6.0.0",
     "jshint-stylish": "^2.0.0",
     "merge-stream": "^0.1.7",
+    "minimist": "^1.2.0",
     "opn": "^1.0.0",
     "polybuild": "^1.0.5",
     "require-dir": "^0.3.0",


### PR DESCRIPTION
You can create a new element by doing `gulp el —new my-element`.  This example will create a new folder under elements called `my-element ` and create a file called `my-element.html` in this folder.  `my-element` is based off `app/elements/starter-element.html`. 

Run `npm install` to install new dependency of minimist.

The purpose of this pr is to make it simpler to create a new basic element. I will update the readme.md with instructions if the team thinks we should add this. What do you think: @addyosmani, @arthurvr, @samccone?