### PR TITLE
Remove css extension checking

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -44,7 +44,7 @@ var styleTask = function (stylesPath, srcs) {
     .pipe($.changed(stylesPath, {extension: '.css'}))
     .pipe($.autoprefixer(AUTOPREFIXER_BROWSERS))
     .pipe(gulp.dest('.tmp/' + stylesPath))
-    .pipe($.if('*.css', $.cssmin()))
+    .pipe($.cssmin())
     .pipe(gulp.dest('dist/' + stylesPath))
     .pipe($.size({title: stylesPath}));
 };


### PR DESCRIPTION
I think we don't need to check extension of css anymore. cause of #6 