### PR TITLE
Remove ES6 support from JSHint.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,7 +1,6 @@
 {
   "node": true,
   "browser": true,
-  "esnext": true,
   "bitwise": true,
   "camelcase": true,
   "curly": true,


### PR DESCRIPTION
JS6 support is now handled as part of of a recipe. See #333.