### PR TITLE
Move bower_components into app folder

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,1 @@
+{"directory": "app/bower_components"}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 node_modules
 dist
-bower_components
+app/bower_components
 .tmp

--- a/app/test/index.html
+++ b/app/test/index.html
@@ -16,8 +16,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <title>Elements Test Runner</title>
     <meta charset="UTF-8">
 
-    <script src="../../bower_components/webcomponentsjs/webcomponents.min.js"></script>
-    <script src="../../bower_components/web-component-tester/browser.js"></script>
+    <script src="../bower_components/webcomponentsjs/webcomponents.min.js"></script>
+    <script src="../bower_components/web-component-tester/browser.js"></script>
   </head>
 
   <body>

--- a/app/test/my-greeting-basic.html
+++ b/app/test/my-greeting-basic.html
@@ -14,10 +14,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
   <title>my-greeting-basic</title>
 
-  <script src="../../bower_components/webcomponentsjs/webcomponents.min.js"></script>
-  <script src="../../bower_components/web-component-tester/browser.js"></script>
-  <script src="../../bower_components/test-fixture/test-fixture-mocha.js"></script>
-  <link rel="import" href="../../bower_components/test-fixture/test-fixture.html">
+  <script src="../bower_components/webcomponentsjs/webcomponents.min.js"></script>
+  <script src="../bower_components/web-component-tester/browser.js"></script>
+  <script src="../bower_components/test-fixture/test-fixture-mocha.js"></script>
+  <link rel="import" href="../bower_components/test-fixture/test-fixture.html">
 
   <!-- Import the element to test -->
   <link rel="import" href="../elements/my-greeting/my-greeting.html">

--- a/app/test/my-list-basic.html
+++ b/app/test/my-list-basic.html
@@ -14,10 +14,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
   <title>my-list-basic</title>
 
-  <script src="../../bower_components/webcomponentsjs/webcomponents.min.js"></script>
-  <script src="../../bower_components/web-component-tester/browser.js"></script>
-  <script src="../../bower_components/test-fixture/test-fixture-mocha.js"></script>
-  <link rel="import" href="../../bower_components/test-fixture/test-fixture.html">
+  <script src="../bower_components/webcomponentsjs/webcomponents.min.js"></script>
+  <script src="../bower_components/web-component-tester/browser.js"></script>
+  <script src="../bower_components/test-fixture/test-fixture-mocha.js"></script>
+  <link rel="import" href="../bower_components/test-fixture/test-fixture.html">
 
   <!-- Import the element to test -->
   <link rel="import" href="../elements/my-list/my-list.html">

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -94,16 +94,16 @@ gulp.task('copy', function () {
   }).pipe(gulp.dest('dist'));
 
   var bower = gulp.src([
-    'bower_components/**/*'
+    'app/bower_components/**/*'
   ]).pipe(gulp.dest('dist/bower_components'));
 
   var elements = gulp.src(['app/elements/**/*.html'])
     .pipe(gulp.dest('dist/elements'));
 
-  var swBootstrap = gulp.src(['bower_components/platinum-sw/bootstrap/*.js'])
+  var swBootstrap = gulp.src(['app/bower_components/platinum-sw/bootstrap/*.js'])
     .pipe(gulp.dest('dist/elements/bootstrap'));
 
-  var swToolbox = gulp.src(['bower_components/sw-toolbox/*.js'])
+  var swToolbox = gulp.src(['app/bower_components/sw-toolbox/*.js'])
     .pipe(gulp.dest('dist/sw-toolbox'));
 
   var vulcanized = gulp.src(['app/elements/elements.html'])
@@ -223,10 +223,7 @@ gulp.task('serve', ['styles', 'elements', 'images'], function () {
     // https: true,
     server: {
       baseDir: ['.tmp', 'app'],
-      middleware: [ historyApiFallback() ],
-      routes: {
-        '/bower_components': 'bower_components'
-      }
+      middleware: [ historyApiFallback() ]
     }
   });
 


### PR DESCRIPTION
When we execute `bower install` from command line, dependencies are placed as the image below

![image](https://cloud.githubusercontent.com/assets/8419829/9836140/94eff6f0-59e4-11e5-81a3-5e61a3d23ff7.png)

I propose placing `bower_components` inside app folder because it's where dependencies are coming from after build... while developing IDEs can provide better IntelliSense once it can find references

![image](https://cloud.githubusercontent.com/assets/8419829/9836150/cf555e02-59e4-11e5-918a-79e65446420e.png)

## Warning
Sorry for creating a pull request not 100% finished... I got it to work with simple `gulp serve`, but running a complete build... webcomponents.js appear two times in the final script and it causes the app not to start