### PR TITLE
Make sure that index.build.html is deleted before proceeding

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -160,11 +160,11 @@ gulp.task('vulcanize', function () {
 // https://github.com/PolymerElements/polymer-starter-kit/#if-you-require-more-granular-configuration-of-vulcanize-than-polybuild-provides-you-an-option-by
 
 // Rename Polybuild's index.build.html to index.html
-gulp.task('rename-index', function () {
+gulp.task('rename-index', function (cb) {
   gulp.src('dist/index.build.html')
     .pipe($.rename('index.html'))
     .pipe(gulp.dest('dist/'));
-  return del(['dist/index.build.html']);
+  return del(['dist/index.build.html'],cb);
 });
 
 // Generate config data for the <sw-precache-cache> element.


### PR DESCRIPTION
`del()` is asynchronous which can cause problems if there are other tasks (i.e. deploy to gh-pages) that depend on the `default` task.
The task will pick up `index.build.html` and thus fail.  
This change will make sure that the `rename-index` task only signals completion once `index.build.html` is deleted. 