### PR TITLE
Fix 'clean' task in gulpfile.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -200,7 +200,7 @@ gulp.task('cache-config', function (callback) {
 
 // Clean output directory
 gulp.task('clean', function (cb) {
-  del(['.tmp', 'dist'], cb);
+  return del(['.tmp', 'dist'], cb);
 });
 
 // Watch files for changes & reload


### PR DESCRIPTION
Task `clean` does not return, thus breaking default gulp task.
Added a `return` statement to fix it.