### PR TITLE
Remove double page refresh when adding jshint + js tasks

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -65,7 +65,6 @@ gulp.task('jshint', function () {
       'app/elements/**/*.js',
       'app/elements/**/*.html'
     ])
-    .pipe(reload({stream: true, once: true}))
     .pipe($.jshint.extract()) // Extract JS from .html files
     .pipe($.jshint())
     .pipe($.jshint.reporter('jshint-stylish'))


### PR DESCRIPTION
Being convinced during the polymer summit by ebidel's talk to try es6
with polymer, I followed docs/add-es2015-support-babel.md.

Adding jshint + js tasks triggers a double refresh request, but only the first
one is executed by the browser, and so, it runs most of the time previous
version of the code (transpiled by babel during last refresh). There is a thus
a race between the first browser refresh request and the transpilation of the
code.

gulp serve gives, when saving a modified elements/**/*.html file:
[18:13:42] Starting 'js'...
[18:13:42] Starting 'jshint'...
[PSK] Reloading Browsers...
[18:13:44] Finished 'jshint' after 1.18 s
[18:13:44] Finished 'js' after 1.76 s
[PSK] Reloading Browsers...

This is due to the jshint task asking explicitely for a one time refresh.
Removing it fixes it and there is then only one refresh, once the code is
properly transpiled.

The new output of gulp serve once a js/html file is modified is:
[18:22:49] Starting 'js'...
[18:22:49] Starting 'jshint'...
[18:22:50] Finished 'jshint' after 1.25 s
[18:22:50] Finished 'js' after 1.62 s
[PSK] Reloading Browsers...

I don't see any reason why the jshint task (which is informational only) would
need to trigger a browser refresh, and thus, I removed it. I may miss something
obvious though… :)
