### PR TITLE
Check gulpfile.js with jshint

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -63,7 +63,8 @@ gulp.task('jshint', function () {
   return gulp.src([
       'app/scripts/**/*.js',
       'app/elements/**/*.js',
-      'app/elements/**/*.html'
+      'app/elements/**/*.html',
+      'gulpfile.js'
     ])
     .pipe(reload({stream: true, once: true}))
     .pipe($.jshint.extract()) // Extract JS from .html files


### PR DESCRIPTION
Currently gulpfile.js is not being checked with jshint. This commit fixes that.