### PR TITLE
del requires the parent directory to be passed as the second argument

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -166,7 +166,7 @@ gulp.task('rename-index', function () {
   gulp.src('dist/index.build.html')
     .pipe($.rename('index.html'))
     .pipe(gulp.dest('dist/'));
-  return del(['dist/index.build.html']);
+  return del(['dist/index.build.html'], gulp.src('dist'));
 });
 
 // Generate config data for the <sw-precache-cache> element.


### PR DESCRIPTION
This is the final fix to the issue:
[#373](https://github.com/PolymerElements/polymer-starter-kit/issues/373)

Looks like [**del**](https://www.npmjs.com/package/del) is not able to find the file for some reason in my system, does not return a promise, it returns **_undefined_** if the parent directory is not provided.

I can provide any additional details you consider may help to identify the origin of the issue if for some reason something in my setup causes [**del**](https://www.npmjs.com/package/del) to behave differently.
