### PR TITLE
Revert back to using Vulcanize over Polybuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,26 +339,6 @@ Don't worry! We've got your covered. Polymer Starter Kit tries to offer everythi
 
 If you find that you just want the simplest setup possible, we recommend using Polymer Starter Kit light, which is available from the [Releases](https://github.com/PolymerElements/polymer-starter-kit/releases) page. This takes next to no time to setup.
 
-### If you require more granular configuration of Vulcanize than polybuild provides you an option by:
-
-1. Copy code below
-2. Then replace `gulp.task('vulcanize', function () {...` entire gulp vulcanize task code in `gulpfile.js`
-
-```javascript
-// Vulcanize granular configuration
-gulp.task('vulcanize', function () {
-  var DEST_DIR = 'dist/elements';
-  return gulp.src('dist/elements/elements.vulcanized.html')
-    .pipe($.vulcanize({
-      stripComments: true,
-      inlineCss: true,
-      inlineScripts: true
-    }))
-    .pipe(gulp.dest(DEST_DIR))
-    .pipe($.size({title: 'vulcanize'}));
-});
-```
-
 ## Contributing
 
 Polymer Starter Kit is a new project and is an ongoing effort by the Web Component community. We welcome your bug reports, PRs for improvements, docs and anything you think would improve the experience for other Polymer developers.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,7 +23,6 @@ var glob = require('glob');
 var historyApiFallback = require('connect-history-api-fallback');
 var packageJson = require('./package.json');
 var crypto = require('crypto');
-var polybuild = require('polybuild');
 
 var AUTOPREFIXER_BROWSERS = [
   'ie >= 10',
@@ -167,27 +166,17 @@ gulp.task('html', function () {
     'dist');
 });
 
-// Polybuild will take care of inlining HTML imports,
-// scripts and CSS for you.
+// Vulcanize granular configuration
 gulp.task('vulcanize', function () {
-  return gulp.src('dist/index.html')
-    .pipe(polybuild({maximumCrush: true}))
-    .pipe(gulp.dest('dist/'));
-});
-
-// If you require more granular configuration of Vulcanize
-// than polybuild provides, follow instructions from readme at:
-// https://github.com/PolymerElements/polymer-starter-kit/#if-you-require-more-granular-configuration-of-vulcanize-than-polybuild-provides-you-an-option-by
-
-// Rename Polybuild's index.build.html to index.html
-gulp.task('rename-index', function () {
-  return gulp.src('dist/index.build.html')
-    .pipe($.rename('index.html'))
-    .pipe(gulp.dest('dist/'));
-});
-
-gulp.task('remove-old-build-index', function () {
-  return del('dist/index.build.html');
+  var DEST_DIR = 'dist/elements';
+  return gulp.src('dist/elements/elements.vulcanized.html')
+    .pipe($.vulcanize({
+      stripComments: true,
+      inlineCss: true,
+      inlineScripts: true
+    }))
+    .pipe(gulp.dest(DEST_DIR))
+    .pipe($.size({title: 'vulcanize'}));
 });
 
 // Generate config data for the <sw-precache-cache> element.
@@ -285,12 +274,12 @@ gulp.task('serve:dist', ['default'], function () {
 
 // Build production files, the default task
 gulp.task('default', ['clean'], function (cb) {
-  // Uncomment 'cache-config' after 'rename-index' if you are going to use service workers.
+  // Uncomment 'cache-config' if you are going to use service workers.
   runSequence(
     ['copy', 'styles'],
     'elements',
     ['jshint', 'images', 'fonts', 'html'],
-    'vulcanize','rename-index', 'remove-old-build-index', // 'cache-config',
+    'vulcanize', // 'cache-config',
     cb);
 });
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "gulp-vulcanize": "^6.0.0",
     "jshint-stylish": "^2.0.0",
     "merge-stream": "^0.1.7",
-    "polybuild": "^1.0.5",
     "require-dir": "^0.3.0",
     "run-sequence": "^1.0.2",
     "vulcanize": ">= 1.4.2",


### PR DESCRIPTION
Per the discussion on our group thread with the team, reverting back to Vulcanize for now.

Polybuild and the transitive dependencies it has currently break in a number of different scenarios, spanning breakage of apps using Firebase in [polyclean](https://github.com/PolymerLabs/polyclean/issues/4) through to issues with how it treats Service Worker scripts, [ES2015](https://github.com/PolymerElements/polymer-starter-kit/issues/369) and so forth. We're confident these issues can be resolved upstream but wish to restore build stability to PSK using the same setup we did in previous releases. 

r @samccone @chuckh 