### PR TITLE
Updated "on-click" to "on-tap"

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -74,17 +74,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         <!-- Drawer Content -->
         <paper-menu class="list" attr-for-selected="data-route" selected="[[route]]">
-          <a data-route="home" href="/" on-click="onDataRouteClick">
+          <a data-route="home" href="/" on-tap="onDataRouteClick">
             <iron-icon icon="home"></iron-icon>
             <span>Home</span>
           </a>
 
-          <a data-route="users" href="/users" on-click="onDataRouteClick">
+          <a data-route="users" href="/users" on-tap="onDataRouteClick">
             <iron-icon icon="info"></iron-icon>
             <span>Users</span>
           </a>
 
-          <a data-route="contact" href="/contact" on-click="onDataRouteClick">
+          <a data-route="contact" href="/contact" on-tap="onDataRouteClick">
             <iron-icon icon="mail"></iron-icon>
             <span>Contact</span>
           </a>


### PR DESCRIPTION
Following the suggestion from the Polymer docs.

>"...tap should be used instead of click for the most reliable cross-platform results."
>https://www.polymer-project.org/1.0/docs/devguide/events.html#gestures