### PR TITLE
fix(README.md): change the attribute name of the cache file

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ To enable Service Worker support for Polymer Starter Kit project use these 3 ste
                         skip-waiting
                         on-service-worker-installed="displayInstalledToast">
     <platinum-sw-cache default-cache-strategy="networkFirst"
-                       precache-file="precache.json">
+                       cache-config-file="precache.json">
     </platinum-sw-cache>
   </platinum-sw-register>
   -->


### PR DESCRIPTION
Hi, I've updated the attribute name in the section about how to enable service worker support. 

The new version of `platinum-sw-register` use a different name. Now is `cache-config-file` but in the current README file says `precache-file` .

Regards.