### PR TITLE
Refactor task cache-config

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,7 +19,7 @@ var reload = browserSync.reload;
 var merge = require('merge-stream');
 var path = require('path');
 var fs = require('fs');
-var glob = require('glob');
+var glob = require('glob-all');
 var historyApiFallback = require('connect-history-api-fallback');
 var packageJson = require('./package.json');
 var crypto = require('crypto');
@@ -193,11 +193,10 @@ gulp.task('cache-config', function (callback) {
     disabled: false
   };
 
-  glob('{elements,scripts,styles}/**/*.*', {cwd: dir}, function(error, files) {
+  glob(['index.html', './', 'bower_components/webcomponentsjs/webcomponents-lite.min.js', '{elements,scripts,styles}/**/*.*'], {cwd: dir}, function(error, files) {
     if (error) {
       callback(error);
     } else {
-      files.push('index.html', './', 'bower_components/webcomponentsjs/webcomponents-lite.min.js');
       config.precache = files;
 
       var md5 = crypto.createHash('md5');

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "connect-history-api-fallback": "^1.1.0",
     "del": "^1.1.1",
     "glob": "^5.0.6",
+    "glob-all": "^3.0.1",
     "gulp": "^3.8.5",
     "gulp-autoprefixer": "^2.1.0",
     "gulp-cache": "^0.2.8",


### PR DESCRIPTION
If you use the package `glob-all` is not necessary to make a push to the array with the files. This way, you can add an array of patterns to the glob function.

Regards.