### PR TITLE
Disable caching for imagemin task (#422)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -58,10 +58,10 @@ var jshintTask = function (src) {
 
 var imageOptimizeTask = function (src, dest) {
   return gulp.src(src)
-    .pipe($.cache($.imagemin({
+    .pipe($.imagemin({
       progressive: true,
       interlaced: true
-    })))
+    }))
     .pipe(gulp.dest(dest))
     .pipe($.size({title: 'images'}));
 };


### PR DESCRIPTION
This is more of a stop-gap than anything, but should alleviate some of the issues we saw over in #422. r: @chuckh 

I haven't been able to understand why SVG files aren't being copied over. We're following the same pattern used in Web Starter Kit and the gulp-imagemin docs.