### PR TITLE
Only run jshint once

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -107,11 +107,7 @@ gulp.task('jshint', function () {
       'app/elements/**/*.js',
       'app/elements/**/*.html',
       'gulpfile.js'
-    ])
-    .pipe($.jshint.extract()) // Extract JS from .html files
-    .pipe($.jshint())
-    .pipe($.jshint.reporter('jshint-stylish'))
-    .pipe($.if(!browserSync.active, $.jshint.reporter('fail')));
+    ]);
 });
 
 // Optimize images


### PR DESCRIPTION
Fixed #478.

The issue was introduced with https://github.com/PolymerElements/polymer-starter-kit/commit/0dc4d13b2495032efb04424f3ae887dac801b1ad for what I can see.