### PR TITLE
Remove extraneous `span` tags

### DIFF
--- a/app/elements/my-greeting/my-greeting.html
+++ b/app/elements/my-greeting/my-greeting.html
@@ -17,7 +17,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         display: block;
       }
     </style>
-    <h2 class="page-title"><span>{{greeting}}</span></h2>
+    <h2 class="page-title">{{greeting}}</h2>
     <span class="paper-font-body2">Update text to change the greeting.</span>
     <!-- Listens for "input" event and sets greeting to <input>.value -->
     <input class="paper-font-body2" value="{{greeting::input}}">

--- a/app/index.html
+++ b/app/index.html
@@ -163,10 +163,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
             <section data-route="user-info">
               <paper-material elevation="1">
-                <h2 class="page-title">
-                User:<span>{{params.name}}</span>
-                </h2>
-                <div>This is <span>{{params.name}}</span>'s section</div>
+                <h2 class="page-title">User: {{params.name}}</h2>
+                <div>This is {{params.name}}'s section</div>
               </paper-material>
             </section>
 


### PR DESCRIPTION
As of Polymer 1.2 these span tags are not necessary anymore and we should provide a good example for users of this starter kit.