### PR TITLE
Use gulp-minify-inline to minimize the elements.vulcanized.html after generation

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -171,6 +171,7 @@ gulp.task('vulcanize', function () {
       inlineCss: true,
       inlineScripts: true
     }))
+    .pipe($.minifyInline())
     .pipe(gulp.dest(DEST_DIR))
     .pipe($.size({title: 'vulcanize'}));
 });

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "gulp-jshint": "^1.6.3",
     "gulp-load-plugins": "^0.10.0",
     "gulp-minify-html": "^1.0.2",
+    "gulp-minify-inline": "^0.1.1",
     "gulp-rename": "^1.2.0",
     "gulp-replace": "^0.5.3",
     "gulp-size": "^1.0.0",


### PR DESCRIPTION
As the `vulcanize` process inlines the JS and CSS for elements, the resulting `elements.vulcanized.html` contains several hundred KB of empty space. By using gulp-minify-inline on the vulcanized file, the size goes from 447K down to around 267K for the default install. Even with gzipped calls, this can be quite a bit of pageload reduced.