### PR TITLE
Fixes app name scale calc (Fixes #491)

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -47,8 +47,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     // appName max size when condensed. The smaller the number the smaller the condensed size.
     var maxMiddleScale = 0.50;
     var auxHeight = heightDiff - detail.y;
-    var auxScale = (heightDiff / (1 - maxMiddleScale)) + maxMiddleScale;
-    var scaleMiddle = Math.max(maxMiddleScale, auxHeight / auxScale);
+    var auxScale = heightDiff / (1 - maxMiddleScale);
+    var scaleMiddle = Math.max(maxMiddleScale, auxHeight / auxScale + maxMiddleScale);
     var scaleBottom = 1 - yRatio;
 
     // Move/translate middleContainer


### PR DESCRIPTION
Before scaleMiddle was always being set to 0.5 (maxMiddleScale). Fixes
#491