### PR TITLE
[Docs] Update ES2015 docs with latest in gulpfile.js changes

### DIFF
--- a/docs/add-es2015-support-babel.md
+++ b/docs/add-es2015-support-babel.md
@@ -49,7 +49,7 @@ Make sure the `js` gulp task is triggered by the common build tasks:
 + gulp.watch(['app/**/*.html'], ['js', reload]);
   gulp.watch(['app/styles/**/*.css'], ['styles', reload]);
   gulp.watch(['app/elements/**/*.css'], ['elements', reload]);
-- gulp.watch(['app/{scripts,elements}/**/*.js'], ['jshint']);
+- gulp.watch(['app/{scripts,elements}/**/*.js'], ['lint']);
 + gulp.watch(['app/{scripts,elements}/**/*.js'], ['lint', 'js']);
   gulp.watch(['app/images/**/*'], reload);
 });

--- a/docs/add-es2015-support-babel.md
+++ b/docs/add-es2015-support-babel.md
@@ -40,8 +40,8 @@ Make sure the `js` gulp task is triggered by the common build tasks:
  - In the gulp `serve` task, make sure `js` is triggered initially and on HTML and JS files changes:
 
 ```patch
--gulp.task('serve', ['styles', 'elements', 'images'], function () {
-+gulp.task('serve', ['styles', 'elements', 'images', 'js'], function () {
+-gulp.task('serve', ['lint', 'styles', 'elements', 'images'], function () {
++gulp.task('serve', ['lint', 'styles', 'elements', 'images', 'js'], function () {
 
   ...
 
@@ -50,7 +50,7 @@ Make sure the `js` gulp task is triggered by the common build tasks:
   gulp.watch(['app/styles/**/*.css'], ['styles', reload]);
   gulp.watch(['app/elements/**/*.css'], ['elements', reload]);
 - gulp.watch(['app/{scripts,elements}/**/*.js'], ['jshint']);
-+ gulp.watch(['app/{scripts,elements}/**/*.js'], ['jshint', 'js']);
++ gulp.watch(['app/{scripts,elements}/**/*.js'], ['lint', 'js']);
   gulp.watch(['app/images/**/*'], reload);
 });
 ```
@@ -66,7 +66,7 @@ gulp.task('default', ['clean'], function (cb) {
     ['copy', 'styles'],
 -   'elements',
 +   ['elements', 'js'],
-    ['jshint', 'images', 'fonts', 'html'],
+    ['lint', 'images', 'fonts', 'html'],
     'vulcanize', // 'cache-config',
     cb);
 });
@@ -79,8 +79,8 @@ gulp.task('default', ['clean'], function (cb) {
  gulp.task('html', function () {
    return optimizeHtmlTask(
 -    ['app/**/*.html', '!app/{elements,test}/**/*.html'],  
-+    ['dist/**/*.html', '!dist/{elements,test}/**/*.html'],
-     'dist');
++    [dist('/**/*.html'), '!' + dist('/{elements,test}/**/*.html')],
+     dist());
  });
  ```
 


### PR DESCRIPTION
Changing to jscs means change jshint to `lint` for function calls; use `dist()` instead of `dist`