### PR TITLE
Add firefox 42 and Chrome stable to travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,12 @@
 language: node_js
+sudo: false
+addons:
+  firefox: '42.0'
+  apt:
+    sources:
+    - google-chrome
+    packages:
+    - google-chrome-stable
 node_js:
   - "4.1"
 before_script:

--- a/app/test/my-greeting-basic.html
+++ b/app/test/my-greeting-basic.html
@@ -16,8 +16,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script src="../../bower_components/webcomponentsjs/webcomponents.min.js"></script>
   <script src="../../bower_components/web-component-tester/browser.js"></script>
-  <script src="../../bower_components/test-fixture/test-fixture-mocha.js"></script>
-  <link rel="import" href="../../bower_components/test-fixture/test-fixture.html">
 
   <!-- Import the element to test -->
   <link rel="import" href="../elements/my-greeting/my-greeting.html">

--- a/app/test/my-list-basic.html
+++ b/app/test/my-list-basic.html
@@ -16,8 +16,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script src="../../bower_components/webcomponentsjs/webcomponents.min.js"></script>
   <script src="../../bower_components/web-component-tester/browser.js"></script>
-  <script src="../../bower_components/test-fixture/test-fixture-mocha.js"></script>
-  <link rel="import" href="../../bower_components/test-fixture/test-fixture.html">
 
   <!-- Import the element to test -->
   <link rel="import" href="../elements/my-list/my-list.html">

--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,6 @@
     "polymer": "Polymer/polymer#^1.2.0"
   },
   "devDependencies": {
-    "test-fixture": "PolymerElements/test-fixture#^1.0.0",
     "web-component-tester": "*"
   },
   "ignore": []

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "require-dir": "^0.3.0",
     "run-sequence": "^1.0.2",
     "vulcanize": ">= 1.4.2",
-    "web-component-tester": "^3.1.3"
+    "web-component-tester": "^3.4.0"
   },
   "scripts": {
     "test": "gulp test:local",


### PR DESCRIPTION
`sudo: false` for the new docker-based build containers (much faster)
Install latest chrome and firefox 42 (workaround travis-ci/travis-ci#5082, broken `firefox: latest`)