### PR TITLE
Switch tests to webcomponents-lite (fixes #473)

### DIFF
--- a/app/test/index.html
+++ b/app/test/index.html
@@ -16,7 +16,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <title>Elements Test Runner</title>
     <meta charset="UTF-8">
 
-    <script src="../../bower_components/webcomponentsjs/webcomponents.min.js"></script>
+    <script src="../../bower_components/webcomponentsjs/webcomponents-lite.min.js"></script>
     <script src="../../bower_components/web-component-tester/browser.js"></script>
   </head>
 

--- a/app/test/my-greeting-basic.html
+++ b/app/test/my-greeting-basic.html
@@ -14,7 +14,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
   <title>my-greeting-basic</title>
 
-  <script src="../../bower_components/webcomponentsjs/webcomponents.min.js"></script>
+  <script src="../../bower_components/webcomponentsjs/webcomponents-lite.min.js"></script>
   <script src="../../bower_components/web-component-tester/browser.js"></script>
 
   <!-- Import the element to test -->

--- a/app/test/my-list-basic.html
+++ b/app/test/my-list-basic.html
@@ -14,7 +14,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
   <title>my-list-basic</title>
 
-  <script src="../../bower_components/webcomponentsjs/webcomponents.min.js"></script>
+  <script src="../../bower_components/webcomponentsjs/webcomponents-lite.min.js"></script>
   <script src="../../bower_components/web-component-tester/browser.js"></script>
 
   <!-- Import the element to test -->


### PR DESCRIPTION
r: @samccone 

Test output on Mac:

```
Installing and starting Selenium server for local browsers
Selenium server running on port 50312
Web server running on port 2000 and serving from /Users/addyo/projects/io-workspace/polymer-starter-kit
safari 9.0.1             Beginning tests via http://localhost:2000/components/polymer-starter-kit/generated-index.html?cli_browser_id=3
safari 9.0.1             Tests passed
firefox 42               Beginning tests via http://localhost:2000/components/polymer-starter-kit/generated-index.html?cli_browser_id=2
chrome 47                Beginning tests via http://localhost:2000/components/polymer-starter-kit/generated-index.html?cli_browser_id=0
chrome 49                Beginning tests via http://localhost:2000/components/polymer-starter-kit/generated-index.html?cli_browser_id=1
firefox 42               Tests passed
chrome 47                Tests passed
chrome 49                Tests passed
Test run ended with great success

chrome 47 (2/0/0)
chrome 49 (2/0/0)
firefox 42 (2/0/0)
safari 9.0.1 (2/0/0)
[14:49:24] Finished 'wct:local' after 10 s
[14:49:24] Starting 'test:local'...
[14:49:24] Finished 'test:local' after 10 μs
```