### PR TITLE
Remove extra space in travis-runner.sh 

### DIFF
--- a/travis-runner.sh
+++ b/travis-runner.sh
@@ -4,7 +4,7 @@ set -o pipefail
 if [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]
 then
   echo "Deploying!" && \
-  sed -i  .tmp "s/\/\/ app.baseUrl = '\/polymer-starter-kit/app.baseUrl = '\/polymer-starter-kit/" app/scripts/app.js && \
+  sed -i .tmp "s/\/\/ app.baseUrl = '\/polymer-starter-kit/app.baseUrl = '\/polymer-starter-kit/" app/scripts/app.js && \
   rm app/scripts/app.js.tmp && \
   bower i && \
   gulp build-deploy-gh-page && \


### PR DESCRIPTION
Remove extra space in first sed command. Hopefully will fix error `sed: -e expression #1, char 1: unknown command: `.'` for travis-ci build process.