### PR TITLE
Use inline_script mode when minifying vulcanized HTML

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -193,7 +193,15 @@ gulp.task('vulcanize', function() {
       inlineCss: true,
       inlineScripts: true
     }))
-    .pipe($.minifyInline())
+    .pipe($.minifyInline({
+      js: {
+        output: {
+          // jshint ignore:start
+          inline_script: true // jscs:ignore requireCamelCaseOrUpperCaseIdentifiers
+          // jshint ignore:end
+        }
+      }
+    }))
     .pipe(gulp.dest(DEST_DIR))
     .pipe($.size({title: 'vulcanize'}));
 });


### PR DESCRIPTION
Ideally this should be fixed in gulp-minify-inline, but for now this should fix some issues related to firebase elements as reported by @johnwhitton on the Polymer Slack.

To go into more detail, before this PR UglifyJS automatically transforms [`'";\x3c/script>'`][1] to `'";</script>'`, which breaks because the string is in an inline `<script>` tag. After this PR, the same string gets transformed into `'";<\/script>'`.

Note that this only applies to strings; UglifyJS does not provide any protection against more sophisticated `</script>` escaping like that in Polymer/vulcanize#280.

[1]: https://github.com/firebase/firebase-bower/blob/master/firebase.js#L171