### PR TITLE
Update href paths in index.html

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -79,12 +79,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             <span>Home</span>
           </a>
 
-          <a data-route="users" href="users">
+          <a data-route="users" href="{{baseUrl}}users">
             <iron-icon icon="info"></iron-icon>
             <span>Users</span>
           </a>
 
-          <a data-route="contact" href="contact">
+          <a data-route="contact" href="{{baseUrl}}contact">
             <iron-icon icon="mail"></iron-icon>
             <span>Contact</span>
           </a>


### PR DESCRIPTION
If you don't add the `{{baseUrl}}`, the href paths are wrong after you go to a specific user's page - i.e. when on `http://localhost:5000/users/Addy`, the **Users** link will take you to `http://localhost:5000/users/users`