### PR TITLE
Fix cache-config-file in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ To enable Service Worker support for Polymer Starter Kit project use these 3 ste
                         skip-waiting
                         on-service-worker-installed="displayInstalledToast">
     <platinum-sw-cache default-cache-strategy="networkFirst"
-                       cache-config-file="precache.json">
+                       cache-config-file="cache-config.json">
     </platinum-sw-cache>
   </platinum-sw-register>
   -->


### PR DESCRIPTION
If you would copy-paste the HTML code in the README.md, it would generate a 404 as `precache.json` was not found.
In `index.html`, this is `cache-config.json` which does not 404.