### PR TITLE
Add friendly error message for missing dotfiles

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -114,7 +114,8 @@ gulp.task('lintfilesExist', function(cb) {
 
   var checked = 0;
   necessaryFiles.forEach(function(file) {
-    fs.stat(__dirname + '/' + file, function(err, stats) {
+    var filePath = path.join(__dirname, file);
+    fs.stat(filePath, function(err, stats) {
       if (err || !stats.isFile()) {
         filesMissing.push(file);
       }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -105,8 +105,33 @@ gulp.task('elements', function() {
   return styleTask('elements', ['**/*.css']);
 });
 
+// Check the files necessary for linting exist.
+// Without this, the 'lint' task can fail with a very non-descriptive message:
+// "TypeError: Cannot convert undefined or null to object"
+gulp.task('lintfilesExist', function(cb) {
+  var necessaryFiles = ['.jscsrc', '.jshintrc'];
+  var filesMissing = [];
+
+  var checked = 0;
+  necessaryFiles.forEach(function(file) {
+    fs.stat(__dirname + '/' + file, function(err, stats) {
+      if (err || !stats.isFile()) {
+        filesMissing.push(file);
+      }
+      checked++;
+      if (checked === necessaryFiles.length) {
+        if (filesMissing.length === 0) {
+          cb();
+        } else {
+          cb('Cannot lint! These necessary files are missing: ' + filesMissing.join(', ') + '.\n');
+        }
+      }
+    });
+  });
+});
+
 // Lint JavaScript
-gulp.task('lint', function() {
+gulp.task('lint', ['lintfilesExist'], function() {
   return gulp.src([
       'app/scripts/**/*.js',
       'app/elements/**/*.js',


### PR DESCRIPTION
Fixes #544.

This provides much more human-readable error messages for when certain dotfiles (namely `.jscsrc` or `.jshintrc`) are missing from the file system.

With the improvement:
<img width="569" alt="screen shot 2015-12-02 at 23 26 38" src="https://cloud.githubusercontent.com/assets/8436403/11544756/46b689e8-994c-11e5-9544-039c152055e7.png">

Previously:
<img width="567" alt="screen shot 2015-12-02 at 23 25 47" src="https://cloud.githubusercontent.com/assets/8436403/11544764/528d3960-994c-11e5-90b3-8ac98519a79d.png">
