### PR TITLE
Fix menu layout issues

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,8 @@
     "paper-elements": "PolymerElements/paper-elements#^1.0.1",
     "platinum-elements": "PolymerElements/platinum-elements#^1.1.0",
     "polymer": "Polymer/polymer#^1.2.0",
-    "paper-menu": "PolymerElements/paper-menu#4fecb43601"
+    "paper-menu": "PolymerElements/paper-menu#4fecb43601",
+    "iron-flex-layout": "PolymerElements/iron-flex-layout#1.2.1"
   },
   "devDependencies": {
     "web-component-tester": "*"


### PR DESCRIPTION
Fixes issues #561, #559, #557 by reverting back to iron-flex-layout
version 1.2.1, version 1.2.2 causes this problem. Still need to find long term fix.

Fixes layout issues for Chrome, Firefox and Safari, but not IE 11 or
Edge (#550).

r: @addyosmani / @samccone 