### PR TITLE
Move bower_components. Make vulcanize easier

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory": "app/bower_components"
+}

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To take advantage of Polymer Starter Kit you need to:
 
 **Intermediate - Advanced**: Use the full version of Polymer Starter Kit. This comes with all the build tools you'll need for testing and productionising your app so it's nice and lean. You'll need to run a few extra commands to install the tools we recommend but it's worth it to make sure your final app is super optimised.
 
-:warning: **Important**: The intermediate/advanced version contains dotfiles (files starting with a `.`). If you're copying the contents of the Starter Kit to a new location make sure you bring along these dotfiles as well! On Mac, [enable showing hidden files](http://ianlunn.co.uk/articles/quickly-showhide-hidden-files-mac-os-x-mavericks/), then try extracting/copying Polymer Starter Kit again. This time the dotfiles needed should be visible so you can copy them over without issues.
+:warning: **Important**: Polymer Starter Kit, and Polymer Starter Kit Light, both contain dotfiles (files starting with a `.`). If you're copying the contents of the Starter Kit to a new location make sure you bring along these dotfiles as well! On Mac, [enable showing hidden files](http://ianlunn.co.uk/articles/quickly-showhide-hidden-files-mac-os-x-mavericks/), then try extracting/copying Polymer Starter Kit again. This time the dotfiles needed should be visible so you can copy them over without issues.
 
 Rob Dodson has a fantastic [PolyCast video](https://www.youtube.com/watch?v=xz-yixRxZN8) available that walks through using Polymer Starter Kit. An [end-to-end with Polymer](https://www.youtube.com/watch?v=1f_Tj_JnStA) and Polymer Starter Kit talk is also available.
 
@@ -161,6 +161,8 @@ Web apps built with Polymer Starter Kit come configured with support for [Web Co
 ## Dependency Management
 
 Polymer uses [Bower](http://bower.io) for package management. This makes it easy to keep your elements up to date and versioned. For tooling, we use npm to manage Node.js-based dependencies.
+
+Components installed by Bower live in the `app/bower_components` directory. This location is specified by the `.bowerrc` file. Many projects which follow Yeoman conventions place the `bower_components` directory outside of the `app` directory and then mount it using a server. This causes problems for tools like [Vulcanize](https://github.com/polymer/vulcanize) and [web-component-shards](https://github.com/PolymerLabs/web-component-shards) which rely on relative paths. We've chosen to simplify things and have `bower_components` live inside of `app` to resolve these issues.
 
 ## Deploy
 
@@ -332,7 +334,7 @@ there is a workaround or fix already posted.
 
 ### I'm having trouble getting Vulcanize to fully build my project on Windows. Help?
 
-Some Windows users have run into trouble with the `elements.vulcanized.html` file in their `dist` folder
+Some Windows users have run into trouble with the `elements.html` file in their `dist` folder
 not being correctly vulcanized. This can happen if your project is in a folder with a name containing a
 space. You can work around this issue by ensuring your path doesn't contain one.
 

--- a/app/index.html
+++ b/app/index.html
@@ -50,9 +50,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script src="bower_components/webcomponentsjs/webcomponents-lite.js"></script>
   <!-- endbuild -->
 
-  <!-- will be replaced with elements/elements.vulcanized.html -->
+  <!-- Because this project uses vulcanize this should be your only html import
+       in this file. All other imports should go in elements.html -->
   <link rel="import" href="elements/elements.html">
-  <!-- endreplace-->
 
   <!-- For shared styles, shared-styles.html import in elements.html -->
   <style is="custom-style" include="shared-styles"></style>
@@ -197,6 +197,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <platinum-sw-register auto-register
                           clients-claim
                           skip-waiting
+                          base-uri="bower_components/platinum-sw/bootstrap"
                           on-service-worker-installed="displayInstalledToast">
       <platinum-sw-cache default-cache-strategy="fastest"
                          cache-config-file="cache-config.json">

--- a/app/test/index.html
+++ b/app/test/index.html
@@ -16,8 +16,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <title>Elements Test Runner</title>
     <meta charset="UTF-8">
 
-    <script src="../../bower_components/webcomponentsjs/webcomponents-lite.min.js"></script>
-    <script src="../../bower_components/web-component-tester/browser.js"></script>
+    <script src="../bower_components/webcomponentsjs/webcomponents-lite.min.js"></script>
+    <script src="../bower_components/web-component-tester/browser.js"></script>
   </head>
 
   <body>

--- a/app/test/my-greeting-basic.html
+++ b/app/test/my-greeting-basic.html
@@ -14,8 +14,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
   <title>my-greeting-basic</title>
 
-  <script src="../../bower_components/webcomponentsjs/webcomponents-lite.min.js"></script>
-  <script src="../../bower_components/web-component-tester/browser.js"></script>
+  <script src="../bower_components/webcomponentsjs/webcomponents-lite.min.js"></script>
+  <script src="../bower_components/web-component-tester/browser.js"></script>
 
   <!-- Import the element to test -->
   <link rel="import" href="../elements/my-greeting/my-greeting.html">

--- a/app/test/my-list-basic.html
+++ b/app/test/my-list-basic.html
@@ -14,8 +14,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
   <title>my-list-basic</title>
 
-  <script src="../../bower_components/webcomponentsjs/webcomponents-lite.min.js"></script>
-  <script src="../../bower_components/web-component-tester/browser.js"></script>
+  <script src="../bower_components/webcomponentsjs/webcomponents-lite.min.js"></script>
+  <script src="../bower_components/web-component-tester/browser.js"></script>
 
   <!-- Import the element to test -->
   <link rel="import" href="../elements/my-list/my-list.html">

--- a/docs/add-es2015-support-babel.md
+++ b/docs/add-es2015-support-babel.md
@@ -13,7 +13,7 @@ This recipe focuses on adding an ES2015 to ES5 transpile step to Polymer Starter
 ```patch
 + // Transpile all JS to ES5.
 + gulp.task('js', function () {
-+  return gulp.src(['app/**/*.{js,html}'])
++  return gulp.src(['app/**/*.{js,html}', '!app/bower_components/**/*'])
 +    .pipe($.sourcemaps.init())
 +    .pipe($.if('*.html', $.crisper())) // Extract JS from .html files
 +    .pipe($.if('*.js', $.babel({

--- a/docs/mobile-chrome-apps.md
+++ b/docs/mobile-chrome-apps.md
@@ -74,14 +74,6 @@ You need to have some changes of configuration to fit for Mobile Chrome Apps as 
 
 ### Update gulp tasks
 
-- Add a glob pattern of restricting files in bower_components to build Android app. `.gz` files can cause building fail for Android. Therefore `!bower_components/web-animations-js/web-animations.min.js.gz` should be added to copy:bower task for that. It would be looks like that.
-  ```js
-  var bower = gulp.src([
-    'bower_components/**/*',
-    '!bower_components/web-animations-js/web-animations.min.js.gz'
-  ]).pipe(gulp.dest(dist('bower_components')));
-  ```
-
 - Using `polybuild(vulcanize + crisper)` task is mandatory because of Chrome Apps doesn't allow inline script blocks according to [CSP](https://developer.chrome.com/apps/contentSecurityPolicy). You should replace current `vulcanize` task with new task below. To do this install `polybuild` first with `npm install --save-dev polybuild` command
   ```js
   // load polybuild
@@ -89,15 +81,14 @@ You need to have some changes of configuration to fit for Mobile Chrome Apps as 
 
   // Vulcanize granular configuration
   gulp.task('vulcanize', function() {
-    var DEST_DIR = dist('elements');
-    return gulp.src(dist('elements/elements.vulcanized.html'))
+    return gulp.src('app/elements/elements.html')
       .pipe(polybuild({maximumCrush: true}))
       .pipe($.rename(function(file) {
         if (file.extname === '.html') {
           file.basename = file.basename.replace('.build', '');
         }
       }))
-      .pipe(gulp.dest(DEST_DIR))
+      .pipe(gulp.dest(dist('elements')))
       .pipe($.size({title: 'vulcanize'}));
   });
   ```


### PR DESCRIPTION
Fixes #562
Should help #512

- Move bower_components into app dir
  - Because we mount the bower_components directory it makes vulcanizing totally insane (hence all the weird stuff where we copied over all of bower_components and vulcanized in the dist directory, instead of vulcanizing in app and writing the output to dist. Doing it this way also screws up tools like `web-component-shards` and Superstatic (as mentioned in #512). I realize it's [a Yeoman convention](http://yeoman.io/blog/bower_components-in-project-root.html) to have bower_components outside of app, but for Polymer projects that makes life very difficult.
- Remove code to rename `elements.html` to `elements.vulcanized.html`. Instead, `dist/elements/elements.html` is just the vulcanized version of `app/elements/elements.html`
- Tell `optimizeHtmlTask` to ignore `bower_components`
- Tell `platinum-sw-register` where to find bootstrap dir with `base-uri` attribute