### PR TITLE
Add dotfile warning to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ To take advantage of Polymer Starter Kit you need to:
 
 **Intermediate - Advanced**: Use the full version of Polymer Starter Kit. This comes with all the build tools you'll need for testing and productionising your app so it's nice and lean. You'll need to run a few extra commands to install the tools we recommend but it's worth it to make sure your final app is super optimised.
 
+:warning: **Important**: The intermediate/advanced version contains dotfiles (files starting with a `.`). If you're copying the contents of the Starter Kit to a new location make sure you bring along these dotfiles as well! On Mac, [enable showing hidden files](http://ianlunn.co.uk/articles/quickly-showhide-hidden-files-mac-os-x-mavericks/), then try extracting/copying Polymer Starter Kit again. This time the dotfiles needed should be visible so you can copy them over without issues.
+
 Rob Dodson has a fantastic [PolyCast video](https://www.youtube.com/watch?v=xz-yixRxZN8) available that walks through using Polymer Starter Kit. An [end-to-end with Polymer](https://www.youtube.com/watch?v=1f_Tj_JnStA) and Polymer Starter Kit talk is also available.
 
 ### Install dependencies


### PR DESCRIPTION
Proposing this as an alternative to https://github.com/PolymerElements/polymer-starter-kit/pull/555
Hopefully improves https://github.com/PolymerElements/polymer-starter-kit/issues/544

Addy has added a write up to the release notes, and hopefully adding this warning to the README also makes it very clear that the user should be on the lookout for those dotfiles. I would much prefer we try to go this route and see if folks still have problems vs. adding new code to the gulpfile to check for missing stuff.

`<tangent>`
I've been feeling that the gulpfile is getting really large and difficult for users to modify and, equally important, for us to safely maintain. https://github.com/PolymerElements/polymer-starter-kit/pull/568 is an attempt to correct some of this. I'd love if we could do some aggressive pruning to get it down as small as possible so it isn't so intimidating.
`</tangent>`