### PR TITLE
Correct Travis CI spelling

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -316,7 +316,7 @@ gulp.task('build-deploy-gh-pages', function(cb) {
 // Deploy to GitHub pages gh-pages branch
 gulp.task('deploy-gh-pages', function() {
   return gulp.src(dist('**/*'))
-    // Check if running task from Travis Cl, if so run using GH_TOKEN
+    // Check if running task from Travis CI, if so run using GH_TOKEN
     // otherwise run using ghPages defaults.
     .pipe($.if(process.env.TRAVIS === 'true', $.ghPages({
       remoteUrl: 'https://$GH_TOKEN@github.com/polymerelements/polymer-starter-kit.git',


### PR DESCRIPTION
CL => CI.  Fixes #578.