### PR TITLE
Update gulp clean task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -232,7 +232,7 @@ gulp.task('cache-config', function(callback) {
 
 // Clean output directory
 gulp.task('clean', function() {
-  return del(['.tmp', dist()]);
+  return del(['.tmp', dist('**'), ['!', dist()].join('')]);
 });
 
 // Watch files for changes & reload


### PR DESCRIPTION
Only clean the contents of the dist dir instead of deleting the dist dir itself.