### PR TITLE
Relax jscs indentation rules

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -2,6 +2,7 @@
   "preset": "google",
   "disallowSpacesInAnonymousFunctionExpression": null,
   "disallowTrailingWhitespace": null,
+  "validateIndentation": null,
   "maximumLineLength": 100,
   "excludeFiles": ["node_modules/**"]
 }


### PR DESCRIPTION
JSCS is barking at a lot of our users, many of whom may be unfamiliar with it. This relaxes JSCS rules around indentation a bit while we sort out the best way to deal with extracted JS

@samccone PTAL