### PR TITLE
Use Superstatic + firebase.json for URL rewriting

### DIFF
--- a/app/elements/my-greeting/my-greeting.html
+++ b/app/elements/my-greeting/my-greeting.html
@@ -26,7 +26,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
     (function() {
       'use strict';
-      
+
       Polymer({
         is: 'my-greeting',
 

--- a/app/elements/routing.html
+++ b/app/elements/routing.html
@@ -65,9 +65,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       page.redirect(app.baseUrl);
     });
 
-    // add #! before urls
     page({
-      hashbang: true
+      // add #! before urls for 
+      // hashbang: true
     });
 
   });

--- a/app/index.html
+++ b/app/index.html
@@ -12,6 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <html lang="en">
 
 <head>
+  <base href="/">
   <meta charset="utf-8">
   <meta name="description" content="">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -31,28 +32,28 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <!-- Add to homescreen for Chrome on Android -->
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="application-name" content="PSK">
-  <link rel="icon" sizes="192x192" href="/images/touch/chrome-touch-icon-192x192.png">
+  <link rel="icon" sizes="192x192" href="images/touch/chrome-touch-icon-192x192.png">
 
   <!-- Add to homescreen for Safari on iOS -->
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-mobile-web-app-title" content="Polymer Starter Kit">
-  <link rel="apple-touch-icon" href="/images/touch/apple-touch-icon.png">
+  <link rel="apple-touch-icon" href="images/touch/apple-touch-icon.png">
 
   <!-- Tile icon for Win8 (144x144) -->
-  <meta name="msapplication-TileImage" content="/images/touch/ms-touch-icon-144x144-precomposed.png">
+  <meta name="msapplication-TileImage" content="images/touch/ms-touch-icon-144x144-precomposed.png">
 
   <!-- build:css styles/main.css -->
-  <link rel="stylesheet" href="/styles/main.css">
+  <link rel="stylesheet" href="styles/main.css">
   <!-- endbuild-->
 
   <!-- build:js bower_components/webcomponentsjs/webcomponents-lite.min.js -->
-  <script src="/bower_components/webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="bower_components/webcomponentsjs/webcomponents-lite.js"></script>
   <!-- endbuild -->
 
   <!-- Because this project uses vulcanize this should be your only html import
        in this file. All other imports should go in elements.html -->
-  <link rel="import" href="/elements/elements.html">
+  <link rel="import" href="elements/elements.html">
 
   <!-- For shared styles, shared-styles.html import in elements.html -->
   <style is="custom-style" include="shared-styles"></style>
@@ -208,7 +209,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </template>
 
   <!-- build:js scripts/app.js -->
-  <script src="/scripts/app.js"></script>
+  <script src="scripts/app.js"></script>
   <!-- endbuild-->
 </body>
 

--- a/app/index.html
+++ b/app/index.html
@@ -31,28 +31,28 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <!-- Add to homescreen for Chrome on Android -->
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="application-name" content="PSK">
-  <link rel="icon" sizes="192x192" href="images/touch/chrome-touch-icon-192x192.png">
+  <link rel="icon" sizes="192x192" href="/images/touch/chrome-touch-icon-192x192.png">
 
   <!-- Add to homescreen for Safari on iOS -->
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-mobile-web-app-title" content="Polymer Starter Kit">
-  <link rel="apple-touch-icon" href="images/touch/apple-touch-icon.png">
+  <link rel="apple-touch-icon" href="/images/touch/apple-touch-icon.png">
 
   <!-- Tile icon for Win8 (144x144) -->
-  <meta name="msapplication-TileImage" content="images/touch/ms-touch-icon-144x144-precomposed.png">
+  <meta name="msapplication-TileImage" content="/images/touch/ms-touch-icon-144x144-precomposed.png">
 
   <!-- build:css styles/main.css -->
-  <link rel="stylesheet" href="styles/main.css">
+  <link rel="stylesheet" href="/styles/main.css">
   <!-- endbuild-->
 
   <!-- build:js bower_components/webcomponentsjs/webcomponents-lite.min.js -->
-  <script src="bower_components/webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="/bower_components/webcomponentsjs/webcomponents-lite.js"></script>
   <!-- endbuild -->
 
   <!-- Because this project uses vulcanize this should be your only html import
        in this file. All other imports should go in elements.html -->
-  <link rel="import" href="elements/elements.html">
+  <link rel="import" href="/elements/elements.html">
 
   <!-- For shared styles, shared-styles.html import in elements.html -->
   <style is="custom-style" include="shared-styles"></style>
@@ -208,7 +208,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </template>
 
   <!-- build:js scripts/app.js -->
-  <script src="scripts/app.js"></script>
+  <script src="/scripts/app.js"></script>
   <!-- endbuild-->
 </body>
 

--- a/docs/deploy-to-firebase-pretty-urls.md
+++ b/docs/deploy-to-firebase-pretty-urls.md
@@ -1,6 +1,6 @@
-# Deploy to Firebase using Pretty URLs
+# Deploy to Firebase Hosting using Pretty URLs
 
-Firebase is a very simple and secure way to deploy a Polymer Starter Kit site. You can sign up for a free account and deploy your application in less than 5 minutes.
+Firebase Hosting is a very simple and secure way to deploy a Polymer Starter Kit site. You can sign up for a free account and deploy your application in less than 5 minutes. [Superstatic](https://github.com/firebase/superstatic) is the open-source web server that is used both by Firebase Hosting and as the local server for `gulp serve` and `gulp serve:dist`.
 
 The instructions below are based on the [Firebase hosting quick start
 guide](https://www.firebase.com/docs/hosting/quickstart.html).
@@ -17,42 +17,11 @@ guide](https://www.firebase.com/docs/hosting/quickstart.html).
 
 1.  `cd` into your project directory
 
-1.  Inititalize the Firebase application
+1.  Create a Firebase project (if you don't have one) at [https://www.firebase.com/account](https://www.firebase.com/account).
 
-        firebase init
+1.  Modify the `firebase.json` file in your project directory and add a `name` property that matches your Firebase project ID (e.g. `my-app` from `my-app.firebaseio.com`).
 
-    Firebase asks you which app you would like to use for hosting. If you just
-    signed up, you should see one app with a randomly-generated name. You can
-    use that one. Otherwise go to
-    [https://www.firebase.com/account](https://www.firebase.com/account) to
-    create a new app.
-
-1.  Firebase asks you the name of your app's public directory. Enter `dist`.
-    This works because when you run `gulp` to build your application, PSK
-    builds everything and places it all in `dist`. So `dist` contains
-    everything your application needs to run.
-
-1.  Edit firebase.json add rewrites section
-
-        {
-          "firebase": "polymer-starter-kit",
-          "public": "dist",
-          "ignore": [
-            "firebase.json",
-            "**/.*",
-            "**/node_modules/**"
-          ],
-          "rewrites": [ {
-            "source": "**",
-            "destination": "/index.html"
-          } ]
-        }
-
-1.  Add `<base href="/">` to `head` in index.html
-
-1.  Remove `hashbang: true` in routing.html near bottom. The call to `page` should look like this now:
-
-        page();
+        {"name": "my-app"}
 
 1.  Build
 

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,14 @@
+{
+  "public": "dist",
+  "ignore": [
+    "firebase.json",
+    "**/.*",
+    "**/node_modules/**"
+  ],
+  "rewrites": [
+    {
+      "source": "!{/bower_components,/elements}/**",
+      "destination": "/index.html"
+    }
+  ]
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,12 +15,12 @@ var $ = require('gulp-load-plugins')();
 var del = require('del');
 var runSequence = require('run-sequence');
 var browserSync = require('browser-sync');
+var superstatic = require('superstatic');
 var reload = browserSync.reload;
 var merge = require('merge-stream');
 var path = require('path');
 var fs = require('fs');
 var glob = require('glob-all');
-var historyApiFallback = require('connect-history-api-fallback');
 var packageJson = require('./package.json');
 var crypto = require('crypto');
 var ensureFiles = require('./tasks/ensure-files.js');
@@ -254,8 +254,12 @@ gulp.task('serve', ['lint', 'styles', 'elements', 'images'], function() {
     //       will present a certificate warning in the browser.
     // https: true,
     server: {
-      baseDir: ['.tmp', 'app'],
-      middleware: [historyApiFallback()]
+      baseDir: ['app'],
+      middleware: [superstatic({
+        config: {
+          public: ['.tmp', 'app']
+        }
+      })]
     }
   });
 
@@ -285,7 +289,7 @@ gulp.task('serve:dist', ['default'], function() {
     //       will present a certificate warning in the browser.
     // https: true,
     server: dist(),
-    middleware: [historyApiFallback()]
+    middleware: [superstatic()]
   });
 });
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "private": true,
   "devDependencies": {
     "browser-sync": "^2.7.7",
-    "connect-history-api-fallback": "^1.1.0",
     "del": "^2.0.2",
     "glob-all": "^3.0.1",
     "gulp": "^3.8.5",
@@ -29,6 +28,7 @@
     "merge-stream": "^1.0.0",
     "require-dir": "^0.3.0",
     "run-sequence": "^1.0.2",
+    "superstatic": "^4.0.0",
     "vulcanize": ">= 1.4.2",
     "web-component-tester": "^4.0.0"
   },


### PR DESCRIPTION
This PR makes some changes likely to have varying degrees of controversy:

1. Use Superstatic as the static web server for URL rewrites
2. Add a `firebase.json` (without app name) to the root (this is picked up by Superstatic)
3. Prefer absolute URLs in `index.html` over `<base>` tag
4. Default to pushState routing over hashbangs
5. Update Firebase deploy guide based on changes

Feedback? kthxbai :cat: 