### PR TITLE
Use paper-menu mixin for selected styles. Fixes Gh-279

### DIFF
--- a/app/styles/app-theme.html
+++ b/app/styles/app-theme.html
@@ -69,13 +69,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     background: white;
   }
 
+  paper-menu {
+    --paper-menu-selected-item: {
+      color: var(--primary-color);
+    }
+
+    --paper-menu-focused-item-after: {
+      background: var(--primary-color);
+    }
+  }
+
   paper-menu iron-icon {
     margin-right: 33px;
     opacity: 0.54;
-  }
-
-  .paper-menu > .iron-selected {
-    color: var(--primary-color);
   }
 
   paper-menu a {


### PR DESCRIPTION
Addresses a small quirk referenced in #279.

Although the `::after` element uses `background: currentcolor` it produces a weird flicker (I guess something to do with the style shimmer) so I'm setting its value as well.