### PR TITLE
Ignore .DS_Store files in gulp copy. Fixes Gh-464

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -150,7 +150,8 @@ gulp.task('copy', function() {
     '!app/test',
     '!app/elements',
     '!app/bower_components',
-    '!app/cache-config.json'
+    '!app/cache-config.json',
+    '!**/.DS_Store'
   ], {
     dot: true
   }).pipe(gulp.dest(dist()));


### PR DESCRIPTION
Ignores .DS_Store files in gulp copy. Per this issue: https://github.com/PolymerElements/polymer-starter-kit/issues/464