### PR TITLE
Revert back to using current paper-menu

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,14 +7,10 @@
     "page": "visionmedia/page.js#~1.6.4",
     "paper-elements": "PolymerElements/paper-elements#^1.0.1",
     "platinum-elements": "PolymerElements/platinum-elements#^1.1.0",
-    "polymer": "Polymer/polymer#^1.2.0",
-    "paper-menu": "PolymerElements/paper-menu#4fecb43601"
+    "polymer": "Polymer/polymer#^1.2.0"
   },
   "devDependencies": {
     "web-component-tester": "*"
   },
-  "ignore": [],
-  "resolutions": {
-    "paper-menu": "4fecb43601"
-  }
+  "ignore": []
 }


### PR DESCRIPTION
paper-menu 1.2.1 menu highlight works now. Fixes #515. I tested on Mac: Chrome 47, Firefox 43, Safari 9.0.1, Windows 10: Edge and IE11, iOS: Safari 9.2 all works fine.

![image](https://cloud.githubusercontent.com/assets/19915/11934699/a3a6d2be-a7b8-11e5-9c88-83598850e044.png)
