### PR TITLE
Update link in REAME from https://www.polymer-project.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ See latest Polymer Starter Kit Demo (from master) at http://polymerelements.gith
 
 ### Tutorials
 
-Check out the Polymer Starter Kit tutorials on [polymer-project.org](https://polymer-project.org):
+Check out the Polymer Starter Kit tutorials on [polymer-project.org](https://www.polymer-project.org):
 
 * [Set up the PSK](https://www.polymer-project.org/1.0/docs/start/psk/set-up.html)
 * [Create a page](https://www.polymer-project.org/1.0/docs/start/psk/create-a-page.html)


### PR DESCRIPTION
The link in the README currently points to `https://polymer-project.org` which generates and error:

```
curl -I https://polymer-project.org/
curl: (35) Encountered end of file
```

The www version `https://www.polymer-project.org` is not a 20x/30x but the site is reachable

```
curl -I https://www.polymer-project.org/
HTTP/1.1 405 Method Not Allowed
Allow: GET
Content-Type: text/html; charset=UTF-8
Content-Length: 188
Date: Tue, 22 Dec 2015 18:41:03 GMT
Server: Google Frontend
Alt-Svc: quic=":443"; ma=604800; v="30,29,28,27,26,25"
```