### PR TITLE
Update dependencies on README.me

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The full starter kit requires the following major dependencies:
 - npm, the node package manager, installed with Node.js and used to install Node.js packages.
 - gulp, a Node.js-based build tool.
 - bower, a Node.js-based package manager used to install front-end packages (like Polymer).
+- node-gyp, a cross-platform command-line tool written in Node.js for compiling native addon modules for Node.js
 
 **To install dependencies:**
 
@@ -74,7 +75,14 @@ npm install -g gulp bower
 
 This lets you run `gulp` and `bower` from the command line.
 
-4)  Install the starter kit's local `npm` and `bower` dependencies.
+4) Install node-gyp and its dependencies
+```sh
+npm install -g node-gyp
+```
+You may need to further install depencies for gyp varying by OS. Detailed instructions can be found on the gyp project: https://github.com/nodejs/node-gyp#installation
+
+
+5)  Install the starter kit's local `npm` and `bower` dependencies.
 
 ```sh
 cd polymer-starter-kit && npm install && bower install

--- a/README.md
+++ b/README.md
@@ -45,14 +45,16 @@ With Node.js installed, run the following one liner from the root of your Polyme
 npm install -g gulp bower && npm install && bower install
 ```
 
-#### Prerequisites (for everyone)
-
+#### Prerequisites 
+##### (for everyone)
 The full starter kit requires the following major dependencies:
-
 - Node.js, used to run JavaScript tools from the command line.
 - npm, the node package manager, installed with Node.js and used to install Node.js packages.
 - gulp, a Node.js-based build tool.
 - bower, a Node.js-based package manager used to install front-end packages (like Polymer).
+
+##### ( for Intermediate-Advanced )
+The Intermediate-Advanced starter kit uses node-gyp and requires the additional depency
 - node-gyp, a cross-platform command-line tool written in Node.js for compiling native addon modules for Node.js
 
 **To install dependencies:**
@@ -75,7 +77,7 @@ npm install -g gulp bower
 
 This lets you run `gulp` and `bower` from the command line.
 
-4) Install node-gyp and its dependencies
+4) (*Intermediate-advanced only*) Install node-gyp and its dependencies
 ```sh
 npm install -g node-gyp
 ```


### PR DESCRIPTION
(For a single issue)
Fixes #633 

This fixes #633 by inserting necessary chronological dependency instructions.

- Added a definition for GYP
- Added a dependency step for gyp.

Further details: 
Important dependency instructions have been left out from the README.me. The node module `node-gyp` is included in this project; trying to run npm-install in the project will crash some way through unless its dependencies are handled prior-hand. This will result in other modules the project is dependent on not to be installed and users will not be able to use `gulp` in their project, which is an important feature to the intermediate to advanced package.