### PR TITLE
Update tag version in the GAE deploy recipe

### DIFF
--- a/docs/deploy-to-google-app-engine.md
+++ b/docs/deploy-to-google-app-engine.md
@@ -70,7 +70,7 @@ The scripts below are based on the [Using Static Files guide](https://cloud.goog
 
     if [ -z "$DEPLOY_VERSION" ]
     then
-      TAG=`git describe`
+      TAG=`git describe --abbrev=0`
       # GAE doesn't allow periods
       DEPLOY_VERSION=${TAG//.}
     fi


### PR DESCRIPTION
The difference is:

- `git describe` returns `v0.3.1-1-g81776a1`

- `git describe --abbrev=0` returns `v0.3.1`