### PR TITLE
GULP SERVE - Watch on scripts directory changes

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -241,6 +241,7 @@ gulp.task('serve', ['styles', 'elements'], function() {
   gulp.watch(['app/**/*.html', '!app/bower_components/**/*.html'], reload);
   gulp.watch(['app/styles/**/*.css'], ['styles', reload]);
   gulp.watch(['app/elements/**/*.css'], ['elements', reload]);
+  gulp.watch(['app/scripts/**/*.js'], reload);
   gulp.watch(['app/images/**/*'], reload);
 });
 


### PR DESCRIPTION
After removing LINT
gulp.watch(['app/{scripts,elements}/**/{*.js,*.html}'], ['lint']);

There's no watching for changes in scripts directory.
This is my temporary fix, before You implement LINT.