### PR TITLE
Set Main Toolbar Color to White

### DIFF
--- a/app/styles/app-theme.html
+++ b/app/styles/app-theme.html
@@ -105,6 +105,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     padding: 0 16px;
   }
 
+  #mainToolbar {
+    color: #fff;
+  }
+
   #mainToolbar.tall .app-name {
     font-size: 40px;
     font-weight: 300;


### PR DESCRIPTION
The main toolbar was show black text and icons, instead of white.

See https://polymerelements.github.io/polymer-starter-kit/ and look at
title text.