### PR TITLE
Remove #mainToolBar color

### DIFF
--- a/app/styles/app-theme.html
+++ b/app/styles/app-theme.html
@@ -105,10 +105,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     padding: 0 16px;
   }
 
-  #mainToolbar {
-    color: #fff;
-  }
-
   #mainToolbar.tall .app-name {
     font-size: 40px;
     font-weight: 300;


### PR DESCRIPTION
Fixed upstream in paper-toolbar to default to white again.  See
paper-toolbar commit:
https://github.com/PolymerElements/paper-toolbar/commit/1f8cc8338220d62f
354b1ab12ae2829222f60a67.  This is part of paper-toolbar release v1.1.4.