### PR TITLE
New 'build' task to replace current 'html' task

### DIFF
--- a/docs/add-es2015-support-babel.md
+++ b/docs/add-es2015-support-babel.md
@@ -78,9 +78,8 @@ gulp.task('default', ['clean'], function(cb) {
  ```patch
  // Scan your HTML for assets & optimize them
  gulp.task('build', ['images', 'fonts'], function() {
-   return optimizeHtmlTask(
--    return gulp.src(['app/**/*.html', '!app/{elements,test,bower_components}/**/*.html'])
-+    return gulp.src(['dist/**/*.html', '!dist/{elements,test,bower_components}/**/*.html'])
+-  return gulp.src(['app/**/*.html', '!app/{elements,test,bower_components}/**/*.html'])
++  return gulp.src(['dist/**/*.html', '!dist/{elements,test,bower_components}/**/*.html'])
 
   ...
  ```

--- a/docs/add-es2015-support-babel.md
+++ b/docs/add-es2015-support-babel.md
@@ -42,8 +42,8 @@ Make sure the `js` gulp task is triggered by the common build tasks:
  - In the gulp `serve` task, make sure `js` is triggered initially and on HTML and JS files changes:
 
 ```patch
-- gulp.task('serve', ['styles'], function () {
-+ gulp.task('serve', ['styles', 'js'], function () {
+- gulp.task('serve', ['styles'], function() {
++ gulp.task('serve', ['styles', 'js'], function() {
 
   ...
 
@@ -54,6 +54,7 @@ Make sure the `js` gulp task is triggered by the common build tasks:
 + gulp.watch(['app/scripts/**/*.js'], ['js', reload]);
   gulp.watch(['app/images/**/*'], reload);
 });
+```
 
  - In the `default` task:
 
@@ -66,7 +67,7 @@ gulp.task('default', ['clean'], function(cb) {
     ['ensureFiles', 'copy', 'styles'],
 +   'js',
 -   ['images', 'fonts', 'html'],
-    'build',
++   'build',
     'vulcanize', // 'cache-config',
     cb);
 });
@@ -76,13 +77,12 @@ gulp.task('default', ['clean'], function(cb) {
 
  ```patch
  // Scan your HTML for assets & optimize them
- gulp.task('build', ['images', 'fonts'], function () {
+ gulp.task('build', ['images', 'fonts'], function() {
    return optimizeHtmlTask(
 -    return gulp.src(['app/**/*.html', '!app/{elements,test,bower_components}/**/*.html'])
 +    return gulp.src(['dist/**/*.html', '!dist/{elements,test,bower_components}/**/*.html'])
 
   ...
-     
  ```
 
 

--- a/docs/add-es2015-support-babel.md
+++ b/docs/add-es2015-support-babel.md
@@ -42,16 +42,16 @@ Make sure the `js` gulp task is triggered by the common build tasks:
  - In the gulp `serve` task, make sure `js` is triggered initially and on HTML and JS files changes:
 
 ```patch
-- gulp.task('serve', ['styles'], function() {
-+ gulp.task('serve', ['styles', 'js'], function () {
+-gulp.task('serve', ['styles'], function () {
++gulp.task('serve', ['styles', 'js'], function () {
 
   ...
 
 - gulp.watch(['app/**/*.html', '!app/bower_components/**/*.html'], reload);
 + gulp.watch(['app/**/*.html', '!app/bower_components/**/*.html'], ['js', reload]);
   gulp.watch(['app/styles/**/*.css'], ['styles', reload]);
-- gulp.watch(['app/scripts/**/*.js'], reload);
-+ gulp.watch(['app/scripts/**/*.js'], ['js', reload]);
+- gulp.watch(['app/{scripts,elements}/**/{*.js,*.html}'], ['lint']);
++ gulp.watch(['app/{scripts,elements}/**/{*.js,*.html}'], ['lint', 'js']);
   gulp.watch(['app/images/**/*'], reload);
 });
 ```
@@ -65,8 +65,8 @@ gulp.task('default', ['clean'], function(cb) {
 
   runSequence(
     ['ensureFiles', 'copy', 'styles'],
-+   'js',
-    ['images', 'fonts', 'html'],
+-   ['build'],
++   ['js', build],
     'vulcanize', // 'cache-config',
     cb);
 });
@@ -76,7 +76,7 @@ gulp.task('default', ['clean'], function(cb) {
 
  ```patch
  // Scan your HTML for assets & optimize them
- gulp.task('html', function() {
+ gulp.task('html', function () {
    return optimizeHtmlTask(
 -    ['app/**/*.html', '!app/{elements,test,bower_components}/**/*.html'],
 +    [dist('/**/*.html'), '!' + dist('/{elements,test,bower_components}/**/*.html')],
@@ -84,10 +84,11 @@ gulp.task('default', ['clean'], function(cb) {
  });
  ```
 
+
  - In the `optimizeHtmlTask` function remove the `searchPath` attribute since all assets should be found under the `dist` folder and we want to make sure we are not picking up duplicates and un-transpiled JS files:
 
 ```patch
-var optimizeHtmlTask = function(src, dest) {
+var optimizeHtmlTask = function (src, dest) {
 - var assets = $.useref.assets({
 -   searchPath: ['.tmp', 'app']
 - });
@@ -110,21 +111,29 @@ Need to change the vulcanize command to grab the newly translated files.  .tmp h
 
 - Add it to the `default` task:
 ```patch
-gulp.task('default', ['clean'], function(cb) {
-  // Uncomment 'cache-config' if you are going to use service workers.
-  runSequence(
-+   'bowertotmp',
-    ['ensureFiles', 'copy', 'styles'],
-    'js',
+ gulp.task('default', ['clean'], function(cb) {
+   // Uncomment 'cache-config' if you are going to use service workers.
+   runSequence(
++    'bowertotmp',
+     ['ensureFiles', 'copy', 'styles'],
+-    ['build'],
++    ['js', 'build'],
+@@ -324,6 +325,12 @@
+    .pipe($.sourcemaps.write('.'))
+    .pipe(gulp.dest('.tmp/'))
+    .pipe(gulp.dest(dist()));
++});
 ```
 
 - Finally update `vulcanize` task to point to `.tmp` directory:
 ```patch
-gulp.task('vulcanize', function() {
-- return gulp.src('app/elements/elements.html')
-+ return gulp.src('.tmp/elements/elements.html')
-    .pipe($.vulcanize({
-      stripComments: true,
+ // Vulcanize granular configuration
+ gulp.task('vulcanize', function() {
+-  return gulp.src('app/elements/elements.html')
++  return gulp.src('.tmp/elements/elements.html')
+     .pipe($.vulcanize({
+       stripComments: true,
+       inlineCss: true,
 ```
 
 

--- a/docs/add-es2015-support-babel.md
+++ b/docs/add-es2015-support-babel.md
@@ -66,8 +66,7 @@ gulp.task('default', ['clean'], function(cb) {
   runSequence(
     ['ensureFiles', 'copy', 'styles'],
 +   'js',
--   ['images', 'fonts', 'html'],
-+   'build',
+    'build',
     'vulcanize', // 'cache-config',
     cb);
 });

--- a/docs/add-eslint-support.md
+++ b/docs/add-eslint-support.md
@@ -18,10 +18,10 @@ This recipe helps you to create a task to use [ESLint](http://eslint.org) tool.
     "html"
   ],
   "globals": {
-    "Polymer": false,
     "__dirname": false,
     "app": false,
     "page": false,
+    "Polymer": false,
     "process": false,
     "require": false
   }
@@ -77,8 +77,7 @@ Make sure the `lint` gulp task is triggered by the common build tasks:
 
   gulp.watch(['app/**/*.html', '!app/bower_components/**/*.html'], reload);
   gulp.watch(['app/styles/**/*.css'], ['styles', reload]);
-- gulp.watch(['app/scripts/**/*.js'], reload);
-+ gulp.watch(['app/scripts/**/*.js'], ['lint', reload]);
++ gulp.watch(['app/{scripts,elements}/**/{*.js,*.html}'], ['lint', reload]);
   gulp.watch(['app/images/**/*'], reload);
 });
 ```
@@ -91,9 +90,10 @@ gulp.task('default', ['clean'], function(cb) {
   // Uncomment 'cache-config' if you are going to use service workers.
   runSequence(
     ['ensureFiles', 'copy', 'styles'],
--   ['images', 'fonts', 'html'],
-+   ['lint', 'images', 'fonts', 'html'],
+-   ['build'],
++   ['lint', 'build'],
     'vulcanize', // 'cache-config',
     cb);
 });
 ```
+

--- a/docs/add-eslint-support.md
+++ b/docs/add-eslint-support.md
@@ -77,7 +77,8 @@ Make sure the `lint` gulp task is triggered by the common build tasks:
 
   gulp.watch(['app/**/*.html', '!app/bower_components/**/*.html'], reload);
   gulp.watch(['app/styles/**/*.css'], ['styles', reload]);
-+ gulp.watch(['app/{scripts,elements}/**/{*.js,*.html}'], ['lint', reload]);
+- gulp.watch(['app/scripts/**/*.js'], reload);
++ gulp.watch(['app/scripts/**/*.js'], ['lint', reload]);
   gulp.watch(['app/images/**/*'], reload);
 });
 ```

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -76,7 +76,6 @@ gulp.task('styles', function() {
   return styleTask('styles', ['**/*.css']);
 });
 
-
 // Ensure that we are not missing required files for the project
 // "dot" files are specifically tricky due to them being hidden on
 // some systems.
@@ -128,7 +127,7 @@ gulp.task('fonts', function() {
 });
 
 // Scan your HTML for assets & optimize them
-gulp.task('build', ['images', 'fonts'], function () {
+gulp.task('build', ['images', 'fonts'], function() {
   return gulp.src(['app/**/*.html', '!app/{elements,test,bower_components}/**/*.html'])
     .pipe($.useref())
     .pipe($.if('*.js', $.uglify({

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -135,6 +135,11 @@ gulp.task('build', ['images', 'fonts'], function () {
       preserveComments: 'some'
     })))
     .pipe($.if('*.css', $.minifyCss()))
+    .pipe($.if('*.html', $.minifyHtml({
+      quotes: true,
+      empty: true,
+      spare: true
+    })))
     .pipe(gulp.dest(dist()))
 });
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "gulp-replace": "^0.5.4",
     "gulp-size": "^2.0.0",
     "gulp-uglify": "^1.2.0",
-    "gulp-useref": "^2.1.0",
+    "gulp-useref": "^3.0.5",
     "gulp-vulcanize": "^6.0.0",
     "merge-stream": "^1.0.0",
     "require-dir": "^0.3.0",


### PR DESCRIPTION
- update gulp-useref to version 3 (it changes [how to use the assets](https://github.com/jonkemp/gulp-useref))
- new 'build' task to replace 'html' task. This new task runs 'images' and 'fonts' and after that, it searchs for the assets in the html files and optimize them.

This way I think that 'default' task is more clear.