### PR TITLE
Update required node version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "start": "gulp serve"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.12.0"
   }
 }


### PR DESCRIPTION
According to the documentation the node version should be at or above 0.12.x.
This just updates the `package.json` accordingly since building with `0.10.x` does not work.