### PR TITLE
Change headers hierarchy to improve accessibility

### DIFF
--- a/app/elements/my-greeting/my-greeting.html
+++ b/app/elements/my-greeting/my-greeting.html
@@ -24,7 +24,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     </style>
 
-    <h2 class="page-title">{{greeting}}</h2>
+    <h1 class="page-title">{{greeting}}</h1>
     <span>Update text to change the greeting.</span>
     <!-- Listens for "input" event and sets greeting to <input>.value -->
     <input value="{{greeting::input}}">

--- a/app/index.html
+++ b/app/index.html
@@ -132,7 +132,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               </paper-material>
 
               <paper-material elevation="1">
-                <h1 id="license">License</h1>
+                <h2 id="license">License</h2>
                 <p>Everything in this repo is BSD style license unless otherwise specified.</p>
                 <p>Copyright (c) 2015 The Polymer Authors. All rights reserved.</p>
                 <p>Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:</p>
@@ -153,7 +153,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
             <section data-route="users">
               <paper-material elevation="1">
-                <h2 class="page-title">Users</h2>
+                <h1 class="page-title">Users</h1>
                 <p>This is the users section</p>
                 <a href$="{{baseUrl}}users/Addy">Addy</a><br>
                 <a href$="{{baseUrl}}users/Rob">Rob</a><br>
@@ -164,14 +164,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
             <section data-route="user-info">
               <paper-material elevation="1">
-                <h2 class="page-title">User: {{params.name}}</h2>
+                <h1 class="page-title">User: {{params.name}}</h1>
                 <div>This is {{params.name}}'s section</div>
               </paper-material>
             </section>
 
             <section data-route="contact">
               <paper-material elevation="1">
-                <h2 class="page-title">Contact</h2>
+                <h1 class="page-title">Contact</h1>
                 <p>This is the contact section</p>
               </paper-material>
             </section>


### PR DESCRIPTION
I've changed the levels of the headers in the examples due to accessibility. I think is better to use a level 1 header for the greetings component to not confuse the users in the examples.

I've used tools like [Claws](https://addons.mozilla.org/es/firefox/addon/claws/) or [Fangs](https://addons.mozilla.org/es/firefox/addon/fangs-screen-reader-emulator/) to review the headers levels.