### PR TITLE
Associate a label with the input control to improve accessibility

### DIFF
--- a/app/elements/my-greeting/my-greeting.html
+++ b/app/elements/my-greeting/my-greeting.html
@@ -25,9 +25,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </style>
 
     <h1 class="page-title">{{greeting}}</h1>
-    <label for="someId">Update text to change the greeting.</label>
+    <label for="greeting-input">Update text to change the greeting.</label>
     <!-- Listens for "input" event and sets greeting to <input>.value -->
-    <input id="someId" value="{{greeting::input}}">
+    <input id="greeting-input" value="{{greeting::input}}">
   </template>
 
   <script>

--- a/app/elements/my-greeting/my-greeting.html
+++ b/app/elements/my-greeting/my-greeting.html
@@ -25,9 +25,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </style>
 
     <h1 class="page-title">{{greeting}}</h1>
-    <span>Update text to change the greeting.</span>
+    <label for="someId">Update text to change the greeting.</label>
     <!-- Listens for "input" event and sets greeting to <input>.value -->
-    <input value="{{greeting::input}}">
+    <input id="someId" value="{{greeting::input}}">
   </template>
 
   <script>


### PR DESCRIPTION
An small and quick fix to improve the accessibility of the my-greeting component. It replaces the span element with a label.

I forgot to include this change in the pull request of yesterday. Sorry for that.