### PR TITLE
Fixes Selenium tests failing #710

### DIFF
--- a/app/test/my-greeting-basic.html
+++ b/app/test/my-greeting-basic.html
@@ -39,7 +39,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       test('Welcome!', function() {
-        header = greeting.$$('h2');
+        header = greeting.$$('h1');
         assert.equal(header.textContent, 'Welcome!');
       });
 


### PR DESCRIPTION
Test broke when `<h2 class="page-title">{{greeting}}</h2>`  was changed to `<h1 class="page-title">{{greeting}}</h1>`.  See:

https://github.com/PolymerElements/polymer-starter-kit/blob/master/app/elements/my-greeting/my-greeting.html#L27

@robdodson PTAL.