### PR TITLE
ignore dist folder

### DIFF
--- a/docs/add-eslint-support.md
+++ b/docs/add-eslint-support.md
@@ -31,8 +31,10 @@ This recipe helps you to create a task to use [ESLint](http://eslint.org/) tool.
 ## Create .eslintignore file in the root folder
 
 ```
-node_modules/*
-bower_components/*
+# /node_modules and /bower_components ignored by default
+
+# Ignore built files
+dist/
 ```
 
 


### PR DESCRIPTION
`node_modules/ ` and `bower_components` will be ignored by default like described in their [documentation](http://eslint.org/docs/user-guide/configuring#ignoring-files-and-directories).

Instead, ignoring the `dist/` makes sense because other than in the gulp task where we explictly define `app/*` a plugin in an editor has it's entry point in the root folder.