### PR TITLE
Update .eslintignore

### DIFF
--- a/docs/add-eslint-support.md
+++ b/docs/add-eslint-support.md
@@ -31,10 +31,8 @@ This recipe helps you to create a task to use [ESLint](http://eslint.org/) tool.
 ## Create .eslintignore file in the root folder
 
 ```
-# /node_modules and /bower_components ignored by default
-
-# Ignore built files
-dist/
+/app/bower_components/**
+/dist/**
 ```
 
 


### PR DESCRIPTION
We need to ignore the `bower_components` because we have it in the app folder, and not in the root folder.