### PR TITLE
Fixes small confusion in documentation regarding requiring backslashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Components installed by Bower live in the `app/bower_components` directory. This
 ### Github Pages
 
 1. Uncomment this line  `// app.baseUrl = '/polymer-starter-kit/';` in app.js near the top
-2. Change `app.baseUrl = '/polymer-starter-kit/';`  to `app.baseUrl = '/your-pathname/';` (ex: if you repo is `github.com/username/bobs-awesome-site` you would change this to `bobs-awesome-site`)
+2. Change `app.baseUrl = '/polymer-starter-kit/';`  to `app.baseUrl = '/your-pathname/';` (ex: if you repo is `github.com/username/bobs-awesome-site` you would change this to `app.baseUrl = '/bobs-awesome-site/';`)
 3. Run `gulp build-deploy-gh-pages` from command line
 4. To see changes wait 1-2 minutes then load Github pages for your app (ex: https://polymerelements.github.io/polymer-starter-kit/)
 

--- a/docs/deploy-to-github-pages.md
+++ b/docs/deploy-to-github-pages.md
@@ -14,7 +14,7 @@ You can deploy to github pages with a couple minor changes to Polymer Starter Ki
   }
   ```
 
-2. Change `app.baseUrl = '/polymer-starter-kit/';`  to `app.baseUrl = '/your-pathname/';` (ex: if you repo is `github.com/username/bobs-awesome-site` you would change this to `bobs-awesome-site`)
+2. Change `app.baseUrl = '/polymer-starter-kit/';`  to `app.baseUrl = '/your-pathname/';` (ex: if you repo is `github.com/username/bobs-awesome-site` you would change this to `app.baseUrl = '/bobs-awesome-site/';`)
 
 3. Add this code at the top of `<head>` tag in the [index.html](../app/index.html) to force HTTPS:
 


### PR DESCRIPTION
This change reduces confusion about using backslashes or not in the URL and is generally more helpful to new comers.