### PR TITLE
Fix the user-info page paper-material elevation

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -166,7 +166,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             </section>
 
             <section data-route="user-info" tabindex="-1">
-              <paper-material elevation="-1">
+              <paper-material elevation="1">
                 <h1 class="page-title" tabindex="-1">User: {{params.name}}</h1>
                 <div>This is {{params.name}}'s section</div>
               </paper-material>


### PR DESCRIPTION
It was recently set to -1 by mistake.