### PR TITLE
Responsively hide drawer panel @840px

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -66,7 +66,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <template is="dom-bind" id="app">
 
-    <paper-drawer-panel id="paperDrawerPanel">
+    <paper-drawer-panel id="paperDrawerPanel" responsive-width="840px">
       <!-- Drawer Scroll Header Panel -->
       <paper-scroll-header-panel drawer fixed>
 


### PR DESCRIPTION
The default responsive width to hide the paper-drawer-panel is an uncomfortable 600px -- let's increase it to 840px, a value consistent with media queries found in the PSK.