### PR TITLE
Replaced deprecated gulp-minify-css with gulp-clean-css

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -56,7 +56,7 @@ var styleTask = function(stylesPath, srcs) {
     .pipe($.changed(stylesPath, {extension: '.css'}))
     .pipe($.autoprefixer(AUTOPREFIXER_BROWSERS))
     .pipe(gulp.dest('.tmp/' + stylesPath))
-    .pipe($.minifyCss())
+    .pipe($.cleanCss())
     .pipe(gulp.dest(dist(stylesPath)))
     .pipe($.size({title: stylesPath}));
 };
@@ -133,7 +133,7 @@ gulp.task('build', ['images', 'fonts'], function() {
     .pipe($.if('*.js', $.uglify({
       preserveComments: 'some'
     })))
-    .pipe($.if('*.css', $.minifyCss()))
+    .pipe($.if('*.css', $.cleanCss()))
     .pipe($.if('*.html', $.minifyHtml({
       quotes: true,
       empty: true,

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "gulp-if": "^2.0.0",
     "gulp-imagemin": "^2.2.1",
     "gulp-load-plugins": "^1.1.0",
-    "gulp-minify-css": "^1.2.1",
+    "gulp-clean-css": "^2.0.3",
     "gulp-minify-html": "^1.0.2",
     "gulp-rename": "^1.2.0",
     "gulp-replace": "^0.5.4",


### PR DESCRIPTION
Fixes issue #761 by replacing gulp-minify-css with gulp-clean-css and updated the gulpfile accordingly. I ran the tests through gulp and also manually verified that the css was minified in the dist folder as it was with the old gulp plugin.