### PR TITLE
PSK2 update .gitignore for deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 bower_components/
 node_modules/
+dist
+.tmp
+.publish/


### PR DESCRIPTION
Until we decide not to use `gulp` with PSK2 we need to ignore `dist`.
Until we change our method to deploy to Github Pages we will still want
`.tmp` and `.publish/`