### PR TITLE
Add 404 section to iron-pages with fallback-selection

### DIFF
--- a/src/psk-app/psk-app.html
+++ b/src/psk-app/psk-app.html
@@ -77,6 +77,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         background-color: #888;
       }
 
+      iron-pages a {
+        color: var(--app-primary-color);
+      }
+
       .main-header {
         border-bottom: 1px solid #ddd;
         background-color: #fff;
@@ -173,10 +177,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         </app-header>
       </app-header-layout>
 
-      <iron-pages selected="[[params.page]]" attr-for-selected="data-page">
+      <iron-pages selected="{{params.page}}"
+                  attr-for-selected="data-page"
+                  fallback-selection="404">
         <psk-page-art data-page="art"></psk-page-art>
         <psk-page-film data-page="film"></psk-page-film>
         <psk-page-design data-page="design"></psk-page-design>
+        <section data-page="404">
+          Oops you hit a 404. <a href="#/art">Head back to home.</a>
+        </section>
       </iron-pages>
     </app-drawer-layout>
   </template>


### PR DESCRIPTION
This PR adds a 404 default message when a specific page could not be found. It uses the recently added property `fallback-selection` (ref: https://github.com/PolymerElements/iron-selector/pull/117)

### How to test?

1. Open the PSK in your browser
* Modify the url by replacing `art` with a non-existing page (for example `asdf`)
* Observe the 404 message is displayed and the URL has been changed to `/#/404`

The last step is due to the two-way binding on the `selected` property. If you do not want to modify the url (e.g. keep the url at `/asdf`) I can revert back to one-way binding.