### PR TITLE
Lazy load polyfill if browser does not support native webcomponents

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,12 +18,39 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <meta name="theme-color" content="#fafafa">
 
     <link rel="manifest" href="manifest.json">
-
-    <script src="../webcomponentsjs/webcomponents-lite.js"></script>
-
     <link rel="import" href="src/psk-app/psk-app.html">
   </head>
   <body>
     <psk-app></psk-app>
+
+    <script>
+      // Load webcomponentsjs polyfill if browser does not support native webcomponents
+      (function() {
+        'use strict';
+        var onload = function() {
+          // For native Imports, manually fire WCR so user code
+          // can use the same code path for native and polyfill'd imports.
+          if (!window.HTMLImports) {
+            document.dispatchEvent(
+                new CustomEvent('WebComponentsReady', {bubbles: true}));
+          }
+        };
+
+        var webComponentsSupported = (
+          'registerElement' in document
+          && 'import' in document.createElement('link')
+          && 'content' in document.createElement('template'));
+
+        if (!webComponentsSupported) {
+          var script = document.createElement('script');
+          script.async = true;
+          script.src = '../webcomponentsjs/webcomponents-lite.min.js';
+          script.onload = onload;
+          document.head.appendChild(script);
+        } else {
+          onload();
+        }
+      })();
+    </script>
   </body>
 </html>


### PR DESCRIPTION
Based on https://gist.github.com/ebidel/1d5ede1e35b6f426a2a7

@justinfagnani confirmed that this should be compatible with the CLI as it just uses `polyserve`.