### PR TITLE
Nitrous.io Quickstart button

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ With Node.js installed, run the following one liner from the root of your Polyme
 npm install -g gulp bower && npm install && bower install
 ```
 
+#### Nitrous Quickstart
+
+You can quickly create a free development environment for this project in the cloud on www.nitrous.io:
+
+<a href="https://www.nitrous.io/quickstart">
+  <img src="https://nitrous-image-icons.s3.amazonaws.com/quickstart.png" alt="Nitrous Quickstart" width=142 height=34>
+</a>
+
+In the IDE, start this project via `Run > Start Polymer Starter Kit` and access your site via `Preview > 5000`.
+
 #### Prerequisites (for everyone)
 
 The full starter kit requires the following major dependencies:

--- a/README.nitrous.md
+++ b/README.nitrous.md
@@ -1,0 +1,13 @@
+# Setup
+
+Welcome to your Polymer Starter Kit project on Nitrous.
+
+## Running the development server:
+
+In the [Nitrous IDE](https://community.nitrous.io/docs/ide-overview), start Polymer Starter Kit via "Run > Start Polymer Starter Kit".
+
+Now you've got a development server running and can see the output in the Nitrous terminal window. You can open up a new shell or utilize [tmux](https://community.nitrous.io/docs/tmux) to open new shells to run other commands.
+
+## Preview the app
+
+In the Nitrous IDE, open the "Preview" menu and click "Port 5000".

--- a/nitrous.json
+++ b/nitrous.json
@@ -1,0 +1,10 @@
+{
+  "template": "nodejs",
+  "ports": [5000, 3001],
+  "name": "Polymer Starter Kit",
+  "description": "A starting point for building web applications with Polymer 1.0",
+  "scripts": {
+    "post-create": "cd ~/code/polymer-starter-kit && echo 'running npm install...' && npm install -g gulp bower && npm install --no-progress && echo 'done npm install' && echo 'running bower install...' && bower install && echo 'bower install done'",
+    "Start Polymer Starter Kit": "cd ~/code/polymer-starter-kit && gulp serve"
+  }
+}


### PR DESCRIPTION
Added Nitrous Quickstart files so anyone can quickly spin up a free, cloud dev environment to start using this repo. Clicking the Quickstart button will automatically clone this repo and will install and configure any required packages.