### PR TITLE
Sample content for all pages and style cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <!doctype html>
-<html>
+<html lang="en">
   <head>
     <title>Polymer Starter Kit</title>
 
@@ -18,6 +18,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <meta name="theme-color" content="#fafafa">
 
     <link rel="manifest" href="manifest.json">
+
+    <!-- Critical pages styles can go here -->
+    <style>
+      body {
+        margin: 0;
+      }
+    </style>
+
     <link rel="import" href="src/psk-app/psk-app.html">
   </head>
   <body>

--- a/src/psk-app/psk-app.html
+++ b/src/psk-app/psk-app.html
@@ -41,9 +41,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <template>
     <style>
       :host {
-        --app-primary-color:  var(--paper-indigo-500);
+        --app-primary-color:  var(--paper-grey-800);
         -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+
+        display: block;
         font-family: 'Roboto', sans-serif;
+        background-color: var(--paper-grey-50);
       }
 
       app-drawer {
@@ -76,11 +79,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       .nav-menu > a.iron-selected {
-        background-color: var(--paper-indigo-800);
+        background-color: var(--paper-grey-600);
       }
 
       iron-pages a {
         color: var(--app-primary-color);
+      }
+
+      iron-pages > * {
+        min-height: 100vh;
       }
 
       .main-header {
@@ -113,23 +120,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         width: 100%;
       }
 
-      .category-page {
-        min-height: 100vh;
-      }
-
       @media (max-width: 580px) {
         /* make title smaller to fit on screen */
         .title {
           font-size: 30px;
           padding-bottom: 16px;
-        }
-      }
-
-      /* narrow layout */
-      @media (max-width: 808px) {
-        article-detail {
-          max-width: none;
-          margin: 0;
         }
       }
     </style>
@@ -175,7 +170,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           <!-- bottom toolbar -->
           <app-toolbar class="title-toolbar main-title-toolbar">
-            <h4 class="title">Polymer Starter Kit</h4>
+            <h1 class="title">Polymer Starter Kit</h1>
           </app-toolbar>
         </app-header>
       </app-header-layout>

--- a/src/psk-page-art/psk-page-art.html
+++ b/src/psk-page-art/psk-page-art.html
@@ -9,6 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../../../polymer/polymer.html">
+<link rel="import" href="../../../app-layout/demo/sample-content.html">
 
 <dom-module id="psk-page-art">
   <template>
@@ -18,7 +19,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     </style>
 
-    <span>psk-page-art</span>
+    <sample-content size="100"></sample-content>
   </template>
   <script>
     Polymer({

--- a/src/psk-page-design/psk-page-design.html
+++ b/src/psk-page-design/psk-page-design.html
@@ -9,6 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../../../polymer/polymer.html">
+<link rel="import" href="../../../app-layout/demo/sample-content.html">
 
 <dom-module id="psk-page-design">
   <template>
@@ -18,7 +19,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     </style>
 
-    <span>psk-page-design</span>
+    <sample-content size="100"></sample-content>
   </template>
   <script>
     Polymer({

--- a/src/psk-page-film/psk-page-film.html
+++ b/src/psk-page-film/psk-page-film.html
@@ -9,6 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../../../polymer/polymer.html">
+<link rel="import" href="../../../app-layout/demo/sample-content.html">
 
 <dom-module id="psk-page-film">
   <template>
@@ -18,7 +19,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     </style>
 
-    <span>psk-page-film</span>
+    <sample-content size="100"></sample-content>
   </template>
   <script>
     Polymer({

--- a/src/psk-page-home/psk-page-home.html
+++ b/src/psk-page-home/psk-page-home.html
@@ -9,6 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../../../polymer/polymer.html">
+<link rel="import" href="../../../app-layout/demo/sample-content.html">
 
 <dom-module id="psk-page-home">
   <template>
@@ -18,7 +19,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     </style>
 
-    <span>psk-page-home</span>
+    <sample-content size="100"></sample-content>
   </template>
   <script>
     Polymer({


### PR DESCRIPTION

<img width="1440" alt="screen shot 2016-04-18 at 9 49 56 pm" src="https://cloud.githubusercontent.com/assets/1066253/14628089/850db1ba-05af-11e6-99c4-4bee499bd82d.png">


- Add `sample-content` taken from app-layout examples
- Switch to greyscale colors
- Remove unused styles
- Add default `lang` to make a11y audit tools happy