### PR TITLE
Add Page Titles

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       body {
         margin: 0;
       }
+
+      /* shared style for page titles */
+      .page-title {
+        font-size: 40px;
+        margin-left: 40px;
+        color: #37474F;
+      }
+
+      @media (max-width: 580px) {
+        /* make page title smaller */
+        .page-title {
+          font-size: 26px;
+        }
+      }
     </style>
 
     <link rel="import" href="src/psk-app/psk-app.html">

--- a/index.html
+++ b/index.html
@@ -24,20 +24,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       body {
         margin: 0;
       }
-
-      /* shared style for page titles */
-      .page-title {
-        font-size: 40px;
-        margin-left: 40px;
-        color: #37474F;
-      }
-
-      @media (max-width: 580px) {
-        /* make page title smaller */
-        .page-title {
-          font-size: 26px;
-        }
-      }
     </style>
 
     <link rel="import" href="src/psk-app/psk-app.html">

--- a/src/psk-page-art/psk-page-art.html
+++ b/src/psk-page-art/psk-page-art.html
@@ -19,6 +19,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     </style>
 
+    <h2 class="page-title">Art</h2>
     <sample-content size="100"></sample-content>
   </template>
   <script>

--- a/src/psk-page-art/psk-page-art.html
+++ b/src/psk-page-art/psk-page-art.html
@@ -10,10 +10,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <link rel="import" href="../../../polymer/polymer.html">
 <link rel="import" href="../../../app-layout/demo/sample-content.html">
+<link rel="import" href="../styles/shared-styles.html">
 
 <dom-module id="psk-page-art">
   <template>
-    <style>
+    <style include="shared-styles">
       :host {
         display: block;
       }

--- a/src/psk-page-design/psk-page-design.html
+++ b/src/psk-page-design/psk-page-design.html
@@ -19,7 +19,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     </style>
 
-    <sample-content size="100"></sample-content>
+    <h2 class="page-title">Design</h2>
+    <sample-content size="2"></sample-content>
   </template>
   <script>
     Polymer({

--- a/src/psk-page-design/psk-page-design.html
+++ b/src/psk-page-design/psk-page-design.html
@@ -10,10 +10,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <link rel="import" href="../../../polymer/polymer.html">
 <link rel="import" href="../../../app-layout/demo/sample-content.html">
+<link rel="import" href="../styles/shared-styles.html">
 
 <dom-module id="psk-page-design">
   <template>
-    <style>
+    <style include="shared-styles">
       :host {
         display: block;
       }

--- a/src/psk-page-film/psk-page-film.html
+++ b/src/psk-page-film/psk-page-film.html
@@ -19,6 +19,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     </style>
 
+    <h2 class="page-title">Film</h2>
     <sample-content size="100"></sample-content>
   </template>
   <script>

--- a/src/psk-page-home/psk-page-home.html
+++ b/src/psk-page-home/psk-page-home.html
@@ -19,6 +19,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     </style>
 
+    <h2 class="page-title">Home</h2>
     <sample-content size="100"></sample-content>
   </template>
   <script>

--- a/src/psk-page-home/psk-page-home.html
+++ b/src/psk-page-home/psk-page-home.html
@@ -10,10 +10,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <link rel="import" href="../../../polymer/polymer.html">
 <link rel="import" href="../../../app-layout/demo/sample-content.html">
+<link rel="import" href="../styles/shared-styles.html">
 
 <dom-module id="psk-page-home">
   <template>
-    <style>
+    <style include="shared-styles">
       :host {
         display: block;
       }

--- a/src/styles/shared-styles.html
+++ b/src/styles/shared-styles.html
@@ -7,25 +7,26 @@ The complete set of contributors may be found at http://polymer.github.io/CONTRI
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
-
 <link rel="import" href="../../../polymer/polymer.html">
-<link rel="import" href="../../../app-layout/demo/sample-content.html">
-<link rel="import" href="../styles/shared-styles.html">
+<link rel="import" href="../../../paper-styles/color.html">
 
-<dom-module id="psk-page-film">
+<!-- shared styles for all elements -->
+<dom-module id="shared-styles">
   <template>
-    <style include="shared-styles">
-      :host {
-        display: block;
+    <style>
+      /* shared style for page titles */
+      .page-title {
+        font-size: 40px;
+        margin-left: 40px;
+        color: var(--paper-grey-800);
+      }
+
+      @media (max-width: 580px) {
+        /* make page title smaller */
+        .page-title {
+          font-size: 26px;
+        }
       }
     </style>
-
-    <h2 class="page-title">Film</h2>
-    <sample-content size="100"></sample-content>
   </template>
-  <script>
-    Polymer({
-      is: 'psk-page-film'
-    });
-  </script>
 </dom-module>


### PR DESCRIPTION
Add page title to each page. When using PSK2 on mobile you can
determine which page you are on without looking at url or opening menu.
 Also made Design page content size 2 to have one short page for
testing.