### PR TITLE
Reenable caching of node_modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ node_js:
   - '0.12'
   - '4.2'
   - '5.1'
+cache:
+  directories:
+    - node_modules
 before_script:
   - 'export DISPLAY=:99.0'
   - sh -e /etc/init.d/xvfb start


### PR DESCRIPTION
This is a resubmission of #775 . The original changes were reverted in #793 . However, the build failed due to problems with installing Chrome, as fixed in #794 .

The failing build log: https://travis-ci.org/PolymerElements/polymer-starter-kit/jobs/122964581#L149

![image](https://cloud.githubusercontent.com/assets/5948271/14833222/7576a5ae-0bfe-11e6-9e03-57fcbe316085.png)
