### PR TITLE
chore: update bower and npm packages

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,15 +2,15 @@
   "name": "polymer-starter-kit",
   "private": true,
   "dependencies": {
-    "iron-elements": "PolymerElements/iron-elements#^1.0.0",
+    "iron-elements": "PolymerElements/iron-elements#^1.0.10",
     "neon-elements": "PolymerElements/neon-elements#^1.0.0",
-    "page": "visionmedia/page.js#~1.6.4",
-    "paper-elements": "PolymerElements/paper-elements#^1.0.1",
-    "platinum-elements": "PolymerElements/platinum-elements#^1.1.0",
-    "polymer": "Polymer/polymer#^1.2.0"
+    "page": "visionmedia/page.js#~1.7.1",
+    "paper-elements": "PolymerElements/paper-elements#^1.0.7",
+    "platinum-elements": "PolymerElements/platinum-elements#^2.0.0",
+    "polymer": "Polymer/polymer#^1.4.0"
   },
   "devDependencies": {
-    "web-component-tester": "^4.0.0"
+    "web-component-tester": "^4.2.2"
   },
   "ignore": []
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "gulp-replace": "^0.5.4",
     "gulp-size": "^2.0.0",
     "gulp-uglify": "^1.2.0",
-    "gulp-useref": "^2.1.0",
+    "gulp-useref": "^3.1.0",
     "gulp-vulcanize": "^6.0.0",
     "merge-stream": "^1.0.0",
     "require-dir": "^0.3.0",


### PR DESCRIPTION
Closes #800

All updates are cosmetic caret bumps with the following exceptions:

[page.js](https://github.com/visionmedia/page.js) - tilde range bumped from 1.6.x to 1.7.x
[platinum-elements](https://github.com/PolymerElements/platinum-elements) - caret range bumped from 1.x to 2.x
[gulp-useref](https://github.com/jonkemp/gulp-useref) - caret range bumped from 2.x to 3.x.

Problems with gulp-useref appear to have been resolved with in the [3.1.0 release](https://github.com/jonkemp/gulp-useref/commit/241dd45cca7debb3b5b13f744479201ec5e7d98b). Given past problems, however, would changing gulp-useref to a new tilde range (i.e. ~3.1.0) be preferable?

Test results: See below asciinema showing all tests passed

[![asciicast](https://asciinema.org/a/44311.png)](https://asciinema.org/a/44311?t=2:08)
