### PR TITLE
PSK2 Added .bowerrc file so that bower components end up in the right foder

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory" : "bower_components"
+}


### PR DESCRIPTION
At the moment, running a bower_install will install everything in a freshly created "app" directory, which won't be found by the component.
With this file, bower components will end up where they are meant to go