### PR TITLE
Separate theming file for app, in line with other page files and easier to deal with/change

### DIFF
--- a/src/psk-app/psk-app.html
+++ b/src/psk-app/psk-app.html
@@ -36,98 +36,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../psk-page-art/psk-page-art.html">
 <link rel="import" href="../psk-page-design/psk-page-design.html">
 <link rel="import" href="../psk-page-film/psk-page-film.html">
+<link rel="import" href="../styles/app-theme.html">
 
 <dom-module id="psk-app">
   <template>
-    <style>
-      :host {
-        --app-primary-color:  var(--paper-grey-800);
-        -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
-
-        display: block;
-        font-family: 'Roboto', sans-serif;
-        background-color: var(--paper-grey-50);
-      }
-
-      app-drawer {
-        --app-drawer-content-container: {
-          background-color: var(--app-primary-color);
-          overflow-x: hidden;
-        };
-      }
-
-      app-drawer app-header {
-        background-color: var(--app-primary-color);
-      }
-
-      .nav-menu {
-        background-color: var(--app-primary-color);
-        color: #fff;
-      }
-
-      a {
-        text-decoration: none;
-        color: inherit;
-        font-size: inherit;
-      }
-
-      .nav-menu > a {
-        display: block;
-        padding: 12px 16px;
-        font-size: 20px;
-        font-weight: 500;
-      }
-
-      .nav-menu > a.iron-selected {
-        background-color: var(--paper-grey-600);
-      }
-
-      iron-pages a {
-        color: var(--app-primary-color);
-      }
-
-      iron-pages > * {
-        min-height: 100vh;
-      }
-
-      .main-header {
-        border-bottom: 1px solid #ddd;
-        background-color: #fff;
-        color: #444;
-      }
-
-      .title-toolbar {
-        @apply(--layout-center-center);
-        width: 100vw;
-        box-sizing: border-box;
-      }
-
-      .title {
-        padding-bottom: 40px;
-        font-size: 50px;
-        font-weight: 800;
-      }
-
-      .nav-title-toolbar {
-        color: #fff;
-      }
-
-      app-drawer-layout:not([narrow]) .nav-title-toolbar {
-        visibility: hidden;
-      }
-
-      app-drawer-layout:not([narrow]) .main-title-toolbar {
-        width: 100%;
-      }
-
-      @media (max-width: 580px) {
-        /* make title smaller to fit on screen */
-        .title {
-          font-size: 30px;
-          padding-bottom: 16px;
-        }
-      }
-    </style>
+    <style include="app-theme"></style>
 
     <!-- setup routes -->
     <carbon-location route="{{route}}"></carbon-location>

--- a/src/psk-app/psk-app.html
+++ b/src/psk-app/psk-app.html
@@ -41,7 +41,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <dom-module id="psk-app">
   <template>
-    <style include-"app-theme">
+    <style include="app-theme">
       :host {
         -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 

--- a/src/styles/app-theme.html
+++ b/src/styles/app-theme.html
@@ -1,0 +1,127 @@
+<!--
+@license
+Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<link rel="import" href="../../bower_components/polymer/polymer.html">
+<link rel="import" href="../../bower_components/paper-styles/color.html">
+
+<!-- shared styles for all elements -->
+<dom-module id="app-theme">
+  <template>
+    <style>
+
+      :host {
+        --app-primary-color:  var(--paper-indigo-500);
+
+        --primary-text-color: var(--paper-grey-900);
+        --primary-background-color: #ffffff;
+        --secondary-text-color: #737373;
+        --disabled-text-color: #9b9b9b;
+        --divider-color: #dbdbdb;
+        --primary-color: var(--paper-indigo-500);
+        --light-primary-color: var(--paper-indigo-100);
+        --dark-primary-color: var(--paper-indigo-700);
+        --accent-color: var(--paper-pink-a200);
+        --light-accent-color: var(--paper-pink-a100);
+        --dark-accent-color: var(--paper-pink-a400);
+        /* Components */
+
+        /* paper-menu */
+        --paper-menu-background-color: #fff;
+        --menu-link-color: #111111;
+
+
+        -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+
+        display: block;
+        font-family: 'Roboto', sans-serif;
+        background-color: var(--paper-grey-50);
+      }
+
+      app-drawer {
+        --app-drawer-content-container: {
+          background-color: var(--app-primary-color);
+          overflow-x: hidden;
+        };
+      }
+
+      app-drawer app-header {
+        background-color: var(--app-primary-color);
+      }
+
+      .nav-menu {
+        background-color: var(--app-primary-color);
+        color: #fff;
+      }
+
+      a {
+        text-decoration: none;
+        color: inherit;
+        font-size: inherit;
+      }
+
+      .nav-menu > a {
+        display: block;
+        padding: 12px 16px;
+        font-size: 20px;
+        font-weight: 500;
+      }
+
+      .nav-menu > a.iron-selected {
+        background-color: var(--paper-grey-600);
+      }
+
+      iron-pages a {
+        color: var(--app-primary-color);
+      }
+
+      iron-pages > * {
+        min-height: 100vh;
+      }
+
+      .main-header {
+        border-bottom: 1px solid #ddd;
+        background-color: #fff;
+        color: #444;
+      }
+
+      .title-toolbar {
+        @apply(--layout-center-center);
+        width: 100vw;
+        box-sizing: border-box;
+      }
+
+      .title {
+        padding-bottom: 40px;
+        font-size: 50px;
+        font-weight: 800;
+      }
+
+      .nav-title-toolbar {
+        color: #fff;
+      }
+
+      app-drawer-layout:not([narrow]) .nav-title-toolbar {
+        visibility: hidden;
+      }
+
+      app-drawer-layout:not([narrow]) .main-title-toolbar {
+        width: 100%;
+      }
+
+      @media (max-width: 580px) {
+        /* make title smaller to fit on screen */
+        .title {
+          font-size: 30px;
+          padding-bottom: 16px;
+        }
+      }
+
+    </style>
+  </template>
+</dom-module>


### PR DESCRIPTION
It really bothered me that PSK2's theming options were inline within psk-app.html. I like the fact that we no longer use a "general" CSS that gets included, and the fact that CSS is set at element-level.
I think it makes a lot more sense this way. Plus, the app looks better too...