### PR TITLE
Fix travis linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ addons:
     packages:
       - google-chrome-stable
 node_js:
-  - '0.12'
   - '4.2'
   - '5.1'
+  - '6.0'
 cache:
   directories:
     - node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_script:
   - npm i -g bower@1.7.1 polymer-cli
   - bower i
 script:
-  - polymer lint
+  - polymer lint --no-recursion
   - polymer test
 env:
   global:


### PR DESCRIPTION
Added `--no-recursion` so Travis CI will pass.  This change will stop
`polymer lint` from linting bower_components.