### PR TITLE
Install only used components

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,8 +3,13 @@
   "dependencies": {
     "app-layout": "PolymerElements/app-layout#^0.9.0",
     "app-route": "PolymerElements/app-route#^0.9.1",
-    "iron-elements": "PolymerElements/iron-elements#^1.0.0",
-    "paper-elements": "PolymerElements/paper-elements#^1.0.0",
+    "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.0.0",
+    "iron-icon": "PolymerElements/iron-icon#^1.0.0",
+    "iron-iconset-svg": "PolymerElements/iron-iconset-svg#^1.0.0",
+    "iron-pages": "PolymerElements/iron-pages#^1.0.0",
+    "iron-selector": "PolymerElements/iron-selector#^1.0.0",
+    "paper-icon-button": "PolymerElements/paper-icon-button#^1.0.0",
+    "paper-styles": "PolymerElements/paper-styles#^1.0.0",
     "polymer": "Polymer/polymer#^1.0.0"
   },
   "private": true


### PR DESCRIPTION
Speeds up `polymer build` process from 58 seconds to 18 seconds. Will also speed deploying to http2 servers since unused components will not be copied to the server.