### PR TITLE
Fixes #847, fixes #817

### DIFF
--- a/src/psk-app/psk-app.html
+++ b/src/psk-app/psk-app.html
@@ -29,9 +29,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../../bower_components/app-layout/app-toolbar/app-toolbar.html">
 
 <link rel="import" href="../app-icons/app-icons.html">
-<link rel="import" href="../psk-page-home/psk-page-home.html">
-<link rel="import" href="../psk-page-about/psk-page-about.html">
-<link rel="import" href="../psk-page-404/psk-page-404.html">
+<link rel="import" href="views/psk-home/psk-home.html">
+<link rel="import" href="views/psk-about/psk-about.html">
+<link rel="import" href="views/psk-404/psk-404.html">
 
 <dom-module id="psk-app">
   <template>
@@ -138,9 +138,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       <!-- main menu -->
       <iron-pages selected="[[pageData.page]]" attr-for-selected="data-page" fallback-selection="404">
-        <psk-page-home data-page=""></psk-page-home>
-        <psk-page-about data-page="about"></psk-page-about>
-        <psk-page-404 data-page="404"></psk-page-404>
+        <psk-home data-page=""></psk-home>
+        <psk-about data-page="about"></psk-about>
+        <psk-404 data-page="404"></psk-404>
       </iron-pages>
     </app-drawer-layout>
   </template>

--- a/src/psk-app/styles/shared-styles.html
+++ b/src/psk-app/styles/shared-styles.html
@@ -8,21 +8,19 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 
-<link rel="import" href="../../bower_components/polymer/polymer.html">
+<link rel="import" href="../../../bower_components/polymer/polymer.html">
+<link rel="import" href="../../../bower_components/paper-styles/color.html">
 
-<dom-module id="psk-page-404">
+<!-- shared styles for all elements -->
+<dom-module id="shared-styles">
   <template>
     <style>
-      :host {
-        display: block;
+      /* shared style for page titles */
+      .page-title {
+        font-size: 26px;
+        margin-left: 40px;
+        color: var(--paper-grey-800);
       }
     </style>
-
-    Oops you hit a 404. <a href="/">Head back to home.</a>
   </template>
-  <script>
-    Polymer({
-      is: 'psk-page-404'
-    });
-  </script>
 </dom-module>

--- a/src/psk-app/views/psk-404/psk-404.html
+++ b/src/psk-app/views/psk-404/psk-404.html
@@ -8,24 +8,21 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 
-<link rel="import" href="../../bower_components/polymer/polymer.html">
-<link rel="import" href="../../bower_components/app-layout/demo/sample-content.html">
-<link rel="import" href="../styles/shared-styles.html">
+<link rel="import" href="../../../../bower_components/polymer/polymer.html">
 
-<dom-module id="psk-page-home">
+<dom-module id="psk-404">
   <template>
-    <style include="shared-styles">
+    <style>
       :host {
         display: block;
       }
     </style>
 
-    <h2 class="page-title">Home</h2>
-    <sample-content size="100"></sample-content>
+    Oops you hit a 404. <a href="/">Head back to home.</a>
   </template>
   <script>
     Polymer({
-      is: 'psk-page-home'
+      is: 'psk-404'
     });
   </script>
 </dom-module>

--- a/src/psk-app/views/psk-about/psk-about.html
+++ b/src/psk-app/views/psk-about/psk-about.html
@@ -8,19 +8,24 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 
-<link rel="import" href="../../bower_components/polymer/polymer.html">
-<link rel="import" href="../../bower_components/paper-styles/color.html">
+<link rel="import" href="../../../../bower_components/polymer/polymer.html">
+<link rel="import" href="../../../../bower_components/app-layout/demo/sample-content.html">
+<link rel="import" href="../../styles/shared-styles.html">
 
-<!-- shared styles for all elements -->
-<dom-module id="shared-styles">
+<dom-module id="psk-about">
   <template>
-    <style>
-      /* shared style for page titles */
-      .page-title {
-        font-size: 26px;
-        margin-left: 40px;
-        color: var(--paper-grey-800);
+    <style include="shared-styles">
+      :host {
+        display: block;
       }
     </style>
+
+    <h2 class="page-title">About</h2>
+    <sample-content size="100"></sample-content>
   </template>
+  <script>
+    Polymer({
+      is: 'psk-about'
+    });
+  </script>
 </dom-module>

--- a/src/psk-app/views/psk-home/psk-home.html
+++ b/src/psk-app/views/psk-home/psk-home.html
@@ -8,11 +8,11 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 
-<link rel="import" href="../../bower_components/polymer/polymer.html">
-<link rel="import" href="../../bower_components/app-layout/demo/sample-content.html">
-<link rel="import" href="../styles/shared-styles.html">
+<link rel="import" href="../../../../bower_components/polymer/polymer.html">
+<link rel="import" href="../../../../bower_components/app-layout/demo/sample-content.html">
+<link rel="import" href="../../styles/shared-styles.html">
 
-<dom-module id="psk-page-about">
+<dom-module id="psk-home">
   <template>
     <style include="shared-styles">
       :host {
@@ -20,12 +20,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     </style>
 
-    <h2 class="page-title">About</h2>
+    <h2 class="page-title">Home</h2>
     <sample-content size="100"></sample-content>
   </template>
   <script>
     Polymer({
-      is: 'psk-page-about'
+      is: 'psk-home'
     });
   </script>
 </dom-module>

--- a/test/index.html
+++ b/test/index.html
@@ -18,8 +18,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <body>
   <script>
     WCT.loadSuites([
-      'psk-page-home.html?dom=shady',
-      'psk-page-home.html?dom=shadow'
+      'psk-home.html?dom=shady',
+      'psk-home.html?dom=shadow'
     ]);
   </script>
 </body>

--- a/test/psk-home.html
+++ b/test/psk-home.html
@@ -18,19 +18,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script src="../bower_components/web-component-tester/browser.js"></script>
 
   <!-- Import the element to test -->
-  <link rel="import" href="../src/psk-page-home/psk-page-home.html">
+  <link rel="import" href="../src/psk-app/views/psk-home/psk-home.html">
 
 </head>
 <body>
 
   <test-fixture id="basic">
     <template>
-       <psk-page-home></psk-page-home>
+       <psk-home></psk-home>
     </template>
   </test-fixture>
 
   <script>
-    suite('psk-page-home tests', function() {
+    suite('psk-home tests', function() {
       var home;
 
       setup(function() {


### PR DESCRIPTION
Fixes #847 by moving elements from src to psk-app/views to make the elements hierarchy be reflected by the directory structure. 

Fixes #817 by allowing for the custom elements to follow the "two-word" naming convention.
