### PR TITLE
Change made to confirm to MD specs

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -179,9 +179,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </paper-scroll-header-panel>
     </paper-drawer-panel>
 
-    <paper-toast id="toast">
-      <span class="toast-hide-button" role="button" tabindex="0" onclick="app.$.toast.hide()">Ok</span>
-    </paper-toast>
+    <paper-toast id="toast"></paper-toast>
 
     <!-- Uncomment next block to enable Service Worker support (1/2) -->
     <!--


### PR DESCRIPTION
This part of the MD specifications says that you shouldn't have dismiss buttons: https://material.google.com/components/snackbars-toasts.html#snackbars-toasts-usage
Continuing PR #865
I tested it and it works. As far as I know there are no toasts without timeout in PSK.