### PR TITLE
Update minimum Node version (like polymer-cli)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/PolymerElements/polymer-starter-kit/issues"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=4.0"
   },
   "private": true
 }


### PR DESCRIPTION
Polymer CLI already use `>=4.0`: [Polymer/polymer-cli/package.json#L7](https://github.com/Polymer/polymer-cli/blob/master/package.json#L7)