### PR TITLE
Polymer build 030

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -41,7 +41,7 @@ let project = new PolymerProject(polymerJSON);
 
 // Clean build directory
 gulp.task('clean', () => {
-  return del(['build/**','!build']);
+  return del(['build/**']);
 });
 
 gulp.task('default',['clean'], (cb) => {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -47,11 +47,6 @@ gulp.task('clean', () => {
 gulp.task('default',['clean'], (cb) => {
 
   let swConfig = {
-    staticFileGlobs: [
-      'index.html',
-      'src/psk-app.html',
-      'src/**',
-    ],
     navigateFallback: '/index.html',
   };
 
@@ -63,7 +58,6 @@ gulp.task('default',['clean'], (cb) => {
       progressive: true, interlaced: true
     })))
     .pipe(project.rejoinHtml());
-    // console.log('sources: ',sources);
 
   // process dependencies
   let dependencies = project.dependencies()

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,6 +15,7 @@ const gulpif = require('gulp-if');
 const imagemin = require('gulp-imagemin');
 const logging = require('plylog');
 const mergeStream = require('merge-stream');
+const del = require('del');
 
 const polymer = require('polymer-build');
 
@@ -27,7 +28,12 @@ const fork = polymer.forkStream;
 let polymerJSON = require('./polymer.json');
 let project = new PolymerProject(polymerJSON);
 
-gulp.task('default', () => {
+// Clean build directory
+gulp.task('clean', () => {
+  return del(['build/**','!build']);
+});
+
+gulp.task('default',['clean'], (cb) => {
 
   // process source files in the project
   let sources = project.sources()

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -41,7 +41,7 @@ let project = new PolymerProject(polymerJSON);
 
 // Clean build directory
 gulp.task('clean', () => {
-  return del(['build/**']);
+  return del('build');
 });
 
 gulp.task('default',['clean'], (cb) => {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "gulp-imagemin": "^3.0.1",
     "merge-stream": "^1.0.0",
     "plylog": "^0.4.0",
-    "polymer-build": "^0.1.0"
+    "polymer-build": "^0.2.0",
+    "del": "^2.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
-  "version": "1.3.0",
+  "name": "polymer-starter-kit",
+  "version": "2.0.0",
   "description": "A starting point for Polymer 1.0 apps",
   "repository": {
     "type": "git",
@@ -14,12 +15,12 @@
   },
   "private": true,
   "devDependencies": {
+    "del": "^2.2.1",
     "gulp": "^3.9.1",
     "gulp-if": "^2.0.1",
     "gulp-imagemin": "^3.0.1",
     "merge-stream": "^1.0.0",
     "plylog": "^0.4.0",
-    "polymer-build": "^0.2.0",
-    "del": "^2.2.1"
+    "polymer-build": "^0.3.0"
   }
 }

--- a/polymer.json
+++ b/polymer.json
@@ -5,5 +5,10 @@
     "src/psk-page-home.html",
     "src/psk-page-about.html",
     "src/psk-page-404.html"
+  ],
+  "sourceGlobs": [
+    "src/**/*",
+    "images/**/*",
+    "bower.json"
   ]
 }

--- a/src/psk-page-404.html
+++ b/src/psk-page-404.html
@@ -15,6 +15,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <style>
       :host {
         display: block;
+        padding: 20px 30px;
       }
     </style>
 

--- a/src/psk-page-about.html
+++ b/src/psk-page-about.html
@@ -9,7 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../bower_components/polymer/polymer.html">
-<link rel="import" href="../bower_components/app-layout/demo/sample-content.html">
+<link rel="import" href="sample-content.html">
 <link rel="import" href="shared-styles.html">
 
 <dom-module id="psk-page-about">

--- a/src/psk-page-home.html
+++ b/src/psk-page-home.html
@@ -9,7 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../bower_components/polymer/polymer.html">
-<link rel="import" href="../bower_components/app-layout/demo/sample-content.html">
+<link rel="import" href="sample-content.html">
 <link rel="import" href="shared-styles.html">
 
 <dom-module id="psk-page-home">

--- a/src/sample-content.html
+++ b/src/sample-content.html
@@ -1,0 +1,102 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../bower_components/polymer/polymer.html">
+
+<dom-module id="sample-content">
+
+  <script>
+
+    Polymer({
+      is: 'sample-content',
+
+      properties: {
+
+        size: {
+          type: Number,
+          value: 0
+        },
+
+        label: {
+          value: ''
+        },
+
+        padding: {
+          value: '16px'
+        },
+
+        margin: {
+          value: '24px'
+        },
+
+        boxShadow: {
+          value: '0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12), 0 3px 1px -2px rgba(0, 0, 0, 0.2)'
+        }
+
+      },
+
+      observers: [
+        '_render(size, label, padding, margin, boxShadow)'
+      ],
+
+      _lorem_ipsum_strings: [
+        'Lorem ipsum dolor sit amet, per in nusquam nominavi periculis, sit elit oportere ea.',
+        'Ut labores minimum atomorum pro. Laudem tibique ut has.',
+        'Fugit adolescens vis et, ei graeci forensibus sed.',
+        'Convenire definiebas scriptorem eu cum. Sit dolor dicunt consectetuer no.',
+        'Ea duis bonorum nec, falli paulo aliquid ei eum.',
+        'Usu eu novum principes, vel quodsi aliquip ea.',
+        'Has at minim mucius aliquam, est id tempor laoreet.',
+        'Pro saepe pertinax ei, ad pri animal labores suscipiantur.',
+        'Detracto suavitate repudiandae no eum. Id adhuc minim soluta nam.',
+        'Iisque perfecto dissentiet cum et, sit ut quot mandamus, ut vim tibique splendide instructior.',
+        'Id nam odio natum malorum, tibique copiosae expetenda mel ea.',
+        'Cu mei vide viris gloriatur, at populo eripuit sit.',
+        'Modus commodo minimum eum te, vero utinam assueverit per eu.',
+        'No nam ipsum lorem aliquip, accumsan quaerendum ei usu.'
+      ],
+
+      ready: function() {
+        this.style.display = 'block';
+      },
+
+      _randomString: function(size) {
+        var ls = this._lorem_ipsum_strings;
+        var s  = '';
+        do {
+          s += ls[Math.floor(Math.random() * ls.length)];
+          size--;
+        } while (size > 0);
+        return s;
+      },
+
+      _randomLetter: function() {
+        return String.fromCharCode(65 + Math.floor(Math.random() * 26));
+      },
+
+      _render: function(size, label, padding, margin, boxShadow) {
+        var html = '';
+        for (var i = 0; i < size; i++) {
+          html +=
+            '<div style="box-shadow: ' + boxShadow +  '; padding: ' + padding + '; margin: ' + margin + '; border-radius: 5px; background-color: #fff; color: #757575;">' +
+            '<div style="display: inline-block; height: 64px; width: 64px; border-radius: 50%; background: #ddd; line-height: 64px; font-size: 30px; color: #555; text-align: center;">' + this._randomLetter() + '</div>' +
+            '<div style="font-size: 22px; margin: 16px 0; color: #212121;">' + this.label + ' '  + this._randomString() + '</div>' +
+            '<p style="font-size: 16px;">' + this._randomString() + '</p>' +
+            '<p style="font-size: 14px;">' + this._randomString(3) + '</p>' +
+            '</div>';
+          this.innerHTML = html;
+        }
+      }
+
+    });
+
+  </script>
+
+</dom-module>


### PR DESCRIPTION
Polymer-build has released version 0.3.0, which breaks the current gulpfile.js and sample-content running from build folders:

**The PR does:**
- Update gulp file for Polymer-build 0.3.0
- Add sample-content to src folder
- Add clean task to gulp file
- NOTE: imagemin is not working yet! Not sure why.

See https://github.com/Polymer/polymer-build/blob/master/test/test-project/gulpfile.js for example gulpfile for version 0.3.0.

@robdodson @abdonrd @justinfagnani PTAL.  See https://github.com/PolymerElements/polymer-starter-kit/compare/psk2...polymer-build-030?expand=1#diff-b9e12334e9eafd8341a6107dd98510c9R62