### PR TITLE
Simplify wct.conf.js

### DIFF
--- a/wct.conf.js
+++ b/wct.conf.js
@@ -7,21 +7,11 @@ The complete set of contributors may be found at http://polymer.github.io/CONTRI
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
-var path = require('path');
-
 var ret = {
   'suites': ['app/test'],
   'webserver': {
     'pathMappings': []
   }
 };
-
-var mapping = {};
-var rootPath = (__dirname).split(path.sep).slice(-1)[0];
-
-mapping['/components/' + rootPath  +
-'/app/bower_components'] = 'bower_components';
-
-ret.webserver.pathMappings.push(mapping);
 
 module.exports = ret;


### PR DESCRIPTION
The magic for bower_components isn't needed, as bower_components is already under 'app' now.

----
Note that even if that path mapping would be needed, it would be simpler to define it directly:
~~~~
 var ret = {
   'suites': ['app/test'],
   'webserver': {
     'pathMappings': [
       { '/components/<basename>/app/bower_components': 'bower_components' }
     ]
   }
 };
~~~~

With this change one could even consider moving from a `wct.conf.js` to a `wct.conf.json`, but that makes adding comments harder -- which is likely what happens when this is used to create a new more complex app.