### PR TITLE
Set focus on title when page changes

### DIFF
--- a/src/manage-focus-behavior.html
+++ b/src/manage-focus-behavior.html
@@ -13,10 +13,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <script>
   Polymer.ManageFocusBehavior = {
     properties: {
-        visible: {
-          type: Boolean,
-          observer: '_visibleChanged'
-        }
+      visible: {
+        type: Boolean,
+        observer: '_visibleChanged'
+      }
     },
     _visibleChanged: function(visible) {
       var title = Polymer.dom(this.root).querySelector('h1'); 

--- a/src/manage-focus-behavior.html
+++ b/src/manage-focus-behavior.html
@@ -11,20 +11,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../bower_components/polymer/polymer.html">
 
 <script>
-  (function() {
-    'use strict';
-    Polymer.MyViewBehavior = {
-      properties: {
-         visible: {
-           type: Boolean,
-           observer: '_visibleChanged'
-         }
-      },
-      _visibleChanged: function(visible) {
-        if (visible) {
-          Polymer.dom(this.root).querySelector('h1').focus();
+  Polymer.ManageFocusBehavior = {
+    properties: {
+        visible: {
+          type: Boolean,
+          observer: '_visibleChanged'
         }
+    },
+    _visibleChanged: function(visible) {
+      var title = Polymer.dom(this.root).querySelector('h1'); 
+      if (visible && title) {
+        title.focus();
       }
-    };
-  })();
+    }
+  };
 </script>

--- a/src/my-app.html
+++ b/src/my-app.html
@@ -93,6 +93,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         <iron-pages
             selected="[[page]]"
+            selected-attribute="visible",
             attr-for-selected="name"
             fallback-selection="view404"
             role="main">

--- a/src/my-app.html
+++ b/src/my-app.html
@@ -21,7 +21,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../bower_components/iron-selector/iron-selector.html">
 <link rel="import" href="../bower_components/paper-icon-button/paper-icon-button.html">
 <link rel="import" href="my-icons.html">
-<link rel="import" href="my-view-behavior.html">
+<link rel="import" href="manage-focus-behavior.html">
 
 <dom-module id="my-app">
   <template>

--- a/src/my-app.html
+++ b/src/my-app.html
@@ -21,6 +21,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../bower_components/iron-selector/iron-selector.html">
 <link rel="import" href="../bower_components/paper-icon-button/paper-icon-button.html">
 <link rel="import" href="my-icons.html">
+<link rel="import" href="my-view-behavior.html">
 
 <dom-module id="my-app">
   <template>

--- a/src/my-view-behavior.html
+++ b/src/my-view-behavior.html
@@ -10,25 +10,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <link rel="import" href="../bower_components/polymer/polymer.html">
 
-<dom-module id="my-view404">
-  <template>
-    <style>
-      :host {
-        display: block;
-
-        padding: 10px 20px;
+<script>
+  (function() {
+    'use strict';
+    Polymer.MyViewBehavior = {
+      properties: {
+         visible: {
+           type: Boolean,
+           observer: '_visibleChanged'
+         }
+      },
+      _visibleChanged: function(visible) {
+        if (visible) {
+          Polymer.dom(this.root).querySelector('h1').focus();
+        }
       }
-    </style>
-
-    <h1 tabindex="-1">Oops you hit a 404. </h1>
-
-    <p><a href="/">Head back to home.</a></p>
-  </template>
-
-  <script>
-    Polymer({
-      is: 'my-view404',
-      behaviors: [Polymer.MyViewBehavior]
-    });
-  </script>
-</dom-module>
+    };
+  })();
+</script>

--- a/src/my-view1.html
+++ b/src/my-view1.html
@@ -32,7 +32,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
     Polymer({
       is: 'my-view1',
-      behaviors: [Polymer.MyViewBehavior]
+      behaviors: [Polymer.ManageFocusBehavior]
     });
   </script>
 </dom-module>

--- a/src/my-view1.html
+++ b/src/my-view1.html
@@ -23,7 +23,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <div class="card">
       <div class="circle">1</div>
-      <h1>View One</h1>
+      <h1 tabindex="-1">View One</h1>
       <p>Ut labores minimum atomorum pro. Laudem tibique ut has.
       <p>Lorem ipsum dolor sit amet, per in nusquam nominavi periculis, sit elit oportere ea.Lorem ipsum dolor sit amet, per in nusquam nominavi periculis, sit elit oportere ea.Cu mei vide viris gloriatur, at populo eripuit sit.</p>
     </div>
@@ -31,7 +31,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script>
     Polymer({
-      is: 'my-view1'
+      is: 'my-view1',
+      properties: {
+         visible: {
+           type: Boolean,
+           observer: '_visibleChanged'
+         }
+       },
+       _visibleChanged: function(visible) {
+         if (visible) {
+           Polymer.dom(this.root).querySelector('h1').focus();
+         }
+       }
     });
   </script>
 </dom-module>

--- a/src/my-view1.html
+++ b/src/my-view1.html
@@ -32,17 +32,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
     Polymer({
       is: 'my-view1',
-      properties: {
-         visible: {
-           type: Boolean,
-           observer: '_visibleChanged'
-         }
-       },
-       _visibleChanged: function(visible) {
-         if (visible) {
-           Polymer.dom(this.root).querySelector('h1').focus();
-         }
-       }
+      behaviors: [Polymer.MyViewBehavior]
     });
   </script>
 </dom-module>

--- a/src/my-view2.html
+++ b/src/my-view2.html
@@ -23,7 +23,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <div class="card">
       <div class="circle">2</div>
-      <h1>View Two</h1>
+      <h1 tabindex="-1">View Two</h1>
       <p>Ea duis bonorum nec, falli paulo aliquid ei eum.</p>
       <p>Id nam odio natum malorum, tibique copiosae expetenda mel ea.Detracto suavitate repudiandae no eum. Id adhuc minim soluta nam.Id nam odio natum malorum, tibique copiosae expetenda mel ea.</p>
     </div>
@@ -31,7 +31,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script>
     Polymer({
-      is: 'my-view2'
+      is: 'my-view2',
+      properties: {
+         visible: {
+           type: Boolean,
+           observer: '_visibleChanged'
+         }
+       },
+       _visibleChanged: function(visible) {
+         if (visible) {
+           Polymer.dom(this.root).querySelector('h1').focus();
+         }
+       }
     });
   </script>
 </dom-module>

--- a/src/my-view2.html
+++ b/src/my-view2.html
@@ -32,7 +32,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
     Polymer({
       is: 'my-view2',
-      behaviors: [Polymer.MyViewBehavior]
+      behaviors: [Polymer.ManageFocusBehavior]
     });
   </script>
 </dom-module>

--- a/src/my-view2.html
+++ b/src/my-view2.html
@@ -32,17 +32,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
     Polymer({
       is: 'my-view2',
-      properties: {
-         visible: {
-           type: Boolean,
-           observer: '_visibleChanged'
-         }
-       },
-       _visibleChanged: function(visible) {
-         if (visible) {
-           Polymer.dom(this.root).querySelector('h1').focus();
-         }
-       }
+      behaviors: [Polymer.MyViewBehavior]
     });
   </script>
 </dom-module>

--- a/src/my-view3.html
+++ b/src/my-view3.html
@@ -23,7 +23,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <div class="card">
       <div class="circle">3</div>
-      <h1>View Three</h1>
+      <h1 tabindex="-1">View Three</h1>
       <p>Modus commodo minimum eum te, vero utinam assueverit per eu.</p>
       <p>Ea duis bonorum nec, falli paulo aliquid ei eum.Has at minim mucius aliquam, est id tempor laoreet.Pro saepe pertinax ei, ad pri animal labores suscipiantur.</p>
     </div>
@@ -31,7 +31,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script>
     Polymer({
-      is: 'my-view3'
+      is: 'my-view3',
+      properties: {
+         visible: {
+           type: Boolean,
+           observer: '_visibleChanged'
+         }
+       },
+       _visibleChanged: function(visible) {
+         if (visible) {
+           Polymer.dom(this.root).querySelector('h1').focus();
+         }
+       }
     });
   </script>
 </dom-module>

--- a/src/my-view3.html
+++ b/src/my-view3.html
@@ -32,7 +32,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
     Polymer({
       is: 'my-view3',
-      behaviors: [Polymer.MyViewBehavior]
+      behaviors: [Polymer.ManageFocusBehavior]
     });
   </script>
 </dom-module>

--- a/src/my-view3.html
+++ b/src/my-view3.html
@@ -32,17 +32,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
     Polymer({
       is: 'my-view3',
-      properties: {
-         visible: {
-           type: Boolean,
-           observer: '_visibleChanged'
-         }
-       },
-       _visibleChanged: function(visible) {
-         if (visible) {
-           Polymer.dom(this.root).querySelector('h1').focus();
-         }
-       }
+      behaviors: [Polymer.MyViewBehavior]
     });
   </script>
 </dom-module>

--- a/src/my-view404.html
+++ b/src/my-view404.html
@@ -20,12 +20,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     </style>
 
-    Oops you hit a 404. <a href="/">Head back to home.</a>
+    <h1 tabindex="-1">Oops you hit a 404. </h1>
+
+    <p><a href="/">Head back to home.</a></p>
   </template>
 
   <script>
     Polymer({
-      is: 'my-view404'
+      is: 'my-view404',
+      properties: {
+         visible: {
+           type: Boolean,
+           observer: '_visibleChanged'
+         }
+       },
+       _visibleChanged: function(visible) {
+         if (visible) {
+           Polymer.dom(this.root).querySelector('h1').focus();
+         }
+       }
     });
   </script>
 </dom-module>

--- a/src/shared-styles.html
+++ b/src/shared-styles.html
@@ -42,10 +42,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       h1 {
         margin: 16px 0;
-
         color: #212121;
-
         font-size: 22px;
+        outline: none;
       }
     </style>
   </template>


### PR DESCRIPTION
The pages use the  `selected-attribute` of `iron-pages` to set the focus on the title when the pages have changed.

This pull request is related with [this one](https://github.com/PolymerElements/polymer-starter-kit/pull/887).
