### PR TITLE
Drawer will hide on page change, unless drawer is persistent

### DIFF
--- a/src/my-app.html
+++ b/src/my-app.html
@@ -123,8 +123,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       _routePageChanged: function(page) {
         this.page = page || 'view1';
-
-        if (!this.$.drawer.persistent) this.$.drawer.opened = false;
+        if (!this.$.drawer.persistent) this.$.drawer.close();
       },
 
       _pageChanged: function(page) {

--- a/src/my-app.html
+++ b/src/my-app.html
@@ -72,7 +72,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <app-drawer-layout fullbleed>
       <!-- Drawer content -->
-      <app-drawer id="drawer" opened="{{drawerOpened}}">
+      <app-drawer id="drawer">
         <app-toolbar>Menu</app-toolbar>
         <iron-selector selected="[[page]]" attr-for-selected="name" class="drawer-list" role="navigation">
           <a name="view1" href="/view1">View One</a>
@@ -124,7 +124,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       _routePageChanged: function(page) {
         this.page = page || 'view1';
 
-        if (!this.$.drawer.persistent) this.drawerOpened = false;
+        if (!this.$.drawer.persistent) this.$.drawer.opened = false;
       },
 
       _pageChanged: function(page) {

--- a/src/my-app.html
+++ b/src/my-app.html
@@ -123,7 +123,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       _routePageChanged: function(page) {
         this.page = page || 'view1';
-        if (!this.$.drawer.persistent) this.$.drawer.close();
+
+        if (!this.$.drawer.persistent) {
+          this.$.drawer.close();
+        }
       },
 
       _pageChanged: function(page) {

--- a/src/my-app.html
+++ b/src/my-app.html
@@ -72,7 +72,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <app-drawer-layout fullbleed>
       <!-- Drawer content -->
-      <app-drawer>
+      <app-drawer id="drawer" opened="{{drawerOpened}}">
         <app-toolbar>Menu</app-toolbar>
         <iron-selector selected="[[page]]" attr-for-selected="name" class="drawer-list" role="navigation">
           <a name="view1" href="/view1">View One</a>
@@ -123,6 +123,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       _routePageChanged: function(page) {
         this.page = page || 'view1';
+
+        if (!this.$.drawer.persistent) this.drawerOpened = false;
       },
 
       _pageChanged: function(page) {


### PR DESCRIPTION
Hi,

The title says it all!
It's only has minor modifications, but with great gains.
I gave an ID to the drawer so that I could refer to it with `this.$.drawer`. I hope that's accetable!

Merc.