### PR TITLE
Add .gitignore as ignore-path to ESLint

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "eslint-plugin-html": "^1.7.0"
   },
   "scripts": {
-    "lint": "eslint . --ext js,html; exit 0;",
+    "lint": "eslint . --ext js,html --ignore-path .gitignore",
     "test": "npm run lint && polymer test"
   }
 }


### PR DESCRIPTION
Add .gitignore as ignore-path to ESLint to avoid lint the `build` folder.

Also, remove the `exit 0;` to avoid the false positive.