### PR TITLE
Fix #981 - Making the starter kit ready for static web servers

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,10 +18,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <title>My App</title>
     <meta name="description" content="My App description">
 
-    <link rel="icon" href="/images/favicon.ico">
+    <link rel="icon" href="./images/favicon.ico">
 
     <!-- See https://goo.gl/OOhYW5 -->
-    <link rel="manifest" href="/manifest.json">
+    <link rel="manifest" href="./manifest.json">
 
     <!-- See https://goo.gl/qRE0vM -->
     <meta name="theme-color" content="#3f51b5">
@@ -36,14 +36,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <meta name="apple-mobile-web-app-title" content="My App">
 
     <!-- Homescreen icons -->
-    <link rel="apple-touch-icon" href="/images/manifest/icon-48x48.png">
-    <link rel="apple-touch-icon" sizes="72x72" href="/images/manifest/icon-72x72.png">
-    <link rel="apple-touch-icon" sizes="96x96" href="/images/manifest/icon-96x96.png">
-    <link rel="apple-touch-icon" sizes="144x144" href="/images/manifest/icon-144x144.png">
-    <link rel="apple-touch-icon" sizes="192x192" href="/images/manifest/icon-192x192.png">
+    <link rel="apple-touch-icon" href="./images/manifest/icon-48x48.png">
+    <link rel="apple-touch-icon" sizes="72x72" href="./images/manifest/icon-72x72.png">
+    <link rel="apple-touch-icon" sizes="96x96" href="./images/manifest/icon-96x96.png">
+    <link rel="apple-touch-icon" sizes="144x144" href="./images/manifest/icon-144x144.png">
+    <link rel="apple-touch-icon" sizes="192x192" href="./images/manifest/icon-192x192.png">
 
     <!-- Tile icon for Windows 8 (144x144 + tile color) -->
-    <meta name="msapplication-TileImage" content="/images/manifest/icon-144x144.png">
+    <meta name="msapplication-TileImage" content="./images/manifest/icon-144x144.png">
     <meta name="msapplication-TileColor" content="#3f51b5">
     <meta name="msapplication-tap-highlight" content="no">
 
@@ -78,7 +78,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         if (!webComponentsSupported) {
           var script = document.createElement('script');
           script.async = true;
-          script.src = '/bower_components/webcomponentsjs/webcomponents-lite.min.js';
+          script.src = './bower_components/webcomponentsjs/webcomponents-lite.min.js';
           script.onload = onload;
           document.head.appendChild(script);
         } else {
@@ -89,12 +89,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // Load pre-caching Service Worker
       if ('serviceWorker' in navigator) {
         window.addEventListener('load', function() {
-          navigator.serviceWorker.register('/service-worker.js');
+          navigator.serviceWorker.register('./service-worker.js');
         });
       }
     </script>
 
-    <link rel="import" href="/src/my-app.html">
+    <link rel="import" href="./src/my-app.html">
 
     <style>
       body {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "My App",
   "short_name": "My App",
-  "start_url": "/?homescreen=1",
+  "start_url": "./?homescreen=1",
   "display": "standalone",
   "theme_color": "#3f51b5",
   "background_color": "#3f51b5",

--- a/src/my-app.html
+++ b/src/my-app.html
@@ -58,7 +58,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     </style>
 
-    <app-location route="{{route}}"></app-location>
+    <app-location route="{{route}}" use-hash-as-path></app-location>
     <app-route
         route="{{route}}"
         pattern="/:page"
@@ -70,9 +70,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <app-drawer id="drawer">
         <app-toolbar>Menu</app-toolbar>
         <iron-selector selected="[[page]]" attr-for-selected="name" class="drawer-list" role="navigation">
-          <a name="view1" href="/view1">View One</a>
-          <a name="view2" href="/view2">View Two</a>
-          <a name="view3" href="/view3">View Three</a>
+          <a name="view1" href="#/view1">View One</a>
+          <a name="view2" href="#/view2">View Two</a>
+          <a name="view3" href="#/view3">View Three</a>
         </iron-selector>
       </app-drawer>
 


### PR DESCRIPTION
Relative paths in index.html and hash instead of path for navigation.

In index.html all the paths used are absolute ones, either for image resources of for the polyfill or for the main component, `my-app ` .

But in many cases, specially when doing code labs, people don't launch the server with the polymer app at its root, they deploy the app in a subfolder. Or they are simply using static webservers. And then all the links are broken.

Making paths relative also require to add `useHashAsPath` to `app-location`, but that's a nice side effect (IMHO)  as you already need to do it when deploying in static web servers.
