### PR TITLE
update travis & package.json to add cli integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,8 @@ node_js:
   - '5'
   - '4'
 before_script:
-  - npm install -g bower polymer-cli
-  - bower install
+  - npm install -g polymer-cli@next
+  - polymer install
 script:
   - xvfb-run npm test
+  - xvfb-run npm run test:integration

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "lint": "eslint . --ext js,html --ignore-path .gitignore",
-    "test": "npm run lint && polymer test"
+    "test": "npm run lint && polymer test",
+    "test:integration": "polymer build # test that psk builds correctly with the CLI"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,6 @@
   "scripts": {
     "lint": "eslint . --ext js,html --ignore-path .gitignore",
     "test": "npm run lint && polymer test",
-    "test:integration": "polymer build # test that psk builds correctly with the CLI"
+    "test:integration": "polymer build # test that psk builds without error with the CLI"
   }
 }


### PR DESCRIPTION
The Polymer CLI supports automatic cloning of the Polymer Starter Kit into an empty directory via the `init` command. However, we occasionally get reports when different CLI commands stop working on the PSK and other templates. 

This PR cleans up the project's travis.yml file a bit, and adds a simple test for all relevant CLI commands  (currently this is just `polymer build`, but when the `polymer lint` command is ready we can add that as well).

There is a sibling PR to add these to the `master` Polymer 1.0 branch as well: https://github.com/PolymerElements/polymer-starter-kit/pull/986

/cc @robdodson @abdonrd @rictic 