### PR TITLE
update readme setup instructions to include bower requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ First, install [Polymer CLI](https://github.com/Polymer/polymer-cli) using
 
     npm install -g polymer-cli
 
+Second, install [Bower](https://bower.io/) using [npm](https://www.npmjs.com)
+
+    npm install -g bower
+
 ##### Initialize project from template
 
     mkdir my-app


### PR DESCRIPTION
if a user attempts to follow the documented setup instructions without bower installed they will receive an error

```
⇒  polymer init starter-kit

info:    Running template polymer-init-starter-kit:app...
info:    Downloading latest release of PolymerElements/polymer-starter-kit
info:    Unpacking template files
info:    Finished writing template files


I'm all done. Running bower install for you to install the required dependencies. If this fails, try running the command yourself.


module.js:472
    throw err;
    ^

Error: Cannot find module 'internal/fs'
    at Function.Module._resolveFilename (module.js:470:15)
    at Function.Module._load (module.js:418:25)
    at Module.require (module.js:498:17)
    at require (internal/module.js:20:19)
    at evalmachine.<anonymous>:18:20
    at Object.<anonymous> (/usr/local/lib/node_modules/bower/node_modules/graceful-fs/fs.js:11:1)
    at Module._compile (module.js:571:32)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
```

installing bower using submitted instructions solves this issue