### PR TITLE
fixes #991 - initial load issue on mobile

### DIFF
--- a/src/my-app.html
+++ b/src/my-app.html
@@ -146,13 +146,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       _pageChanged(page) {
         // Load page import on demand. Show 404 page if fails
         var resolvedPageUrl = this.resolveUrl('my-' + page + '.html');
-        Polymer.RenderStatus.afterNextRender(this, function() {
+        Polymer.RenderStatus.afterNextRender(this, () => {
           Polymer.importHref(
               resolvedPageUrl,
               null,
               this._showPage404.bind(this),
               true);
-        }.bind(this));
+        });
       }
 
       _showPage404() {

--- a/src/my-app.html
+++ b/src/my-app.html
@@ -146,11 +146,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       _pageChanged(page) {
         // Load page import on demand. Show 404 page if fails
         var resolvedPageUrl = this.resolveUrl('my-' + page + '.html');
-        Polymer.importHref(
-            resolvedPageUrl,
-            null,
-            this._showPage404.bind(this),
-            true);
+        Polymer.RenderStatus.afterNextRender(this, function () {
+          Polymer.importHref(
+              resolvedPageUrl,
+              null,
+              this._showPage404.bind(this),
+              true);
+        }.bind(this));
       }
 
       _showPage404() {

--- a/src/my-app.html
+++ b/src/my-app.html
@@ -146,7 +146,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       _pageChanged(page) {
         // Load page import on demand. Show 404 page if fails
         var resolvedPageUrl = this.resolveUrl('my-' + page + '.html');
-        Polymer.RenderStatus.afterNextRender(this, function () {
+        Polymer.RenderStatus.afterNextRender(this, function() {
           Polymer.importHref(
               resolvedPageUrl,
               null,


### PR DESCRIPTION
polymer-starter-kit is showing a 404 page when loading a valid route on the browser, though the navigation works fine once the page finished loading. Refreshing brings the 404 view again.
This PR fixes the issue.