### PR TITLE
travis: remove node v5, add node latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ addons:
     packages:
       - google-chrome-stable
 node_js:
+  - node
   - '6'
-  - '5'
   - '4'
 before_script:
   - npm install -g polymer-cli@next


### PR DESCRIPTION
Node v5 is no longer supported by Polymer or even the Node team. Lets change travis to test LTS & the latest version as per our support policy.