### PR TITLE
Change PSK 3.0 / 2.0-preview to use relative paths for subdirectory deployment

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <title>My App</title>
     <meta name="description" content="My App description">
 
-    <!-- Set to project directory if not serving from root -->
+    <!--
+      If deploying to a non-root path, replace href="/" with the full path to the project root.
+      For example: href="/polymer-starter-kit/relative-path-example/"
+    -->
     <base href="/">
 
     <link rel="icon" href="images/favicon.ico">

--- a/index.html
+++ b/index.html
@@ -18,10 +18,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <title>My App</title>
     <meta name="description" content="My App description">
 
-    <link rel="icon" href="/images/favicon.ico">
+    <!-- Set to project directory if not serving from root -->
+    <base href="/">
+
+    <link rel="icon" href="images/favicon.ico">
 
     <!-- See https://goo.gl/OOhYW5 -->
-    <link rel="manifest" href="/manifest.json">
+    <link rel="manifest" href="manifest.json">
 
     <!-- See https://goo.gl/qRE0vM -->
     <meta name="theme-color" content="#3f51b5">
@@ -36,31 +39,33 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <meta name="apple-mobile-web-app-title" content="My App">
 
     <!-- Homescreen icons -->
-    <link rel="apple-touch-icon" href="/images/manifest/icon-48x48.png">
-    <link rel="apple-touch-icon" sizes="72x72" href="/images/manifest/icon-72x72.png">
-    <link rel="apple-touch-icon" sizes="96x96" href="/images/manifest/icon-96x96.png">
-    <link rel="apple-touch-icon" sizes="144x144" href="/images/manifest/icon-144x144.png">
-    <link rel="apple-touch-icon" sizes="192x192" href="/images/manifest/icon-192x192.png">
+    <link rel="apple-touch-icon" href="images/manifest/icon-48x48.png">
+    <link rel="apple-touch-icon" sizes="72x72" href="images/manifest/icon-72x72.png">
+    <link rel="apple-touch-icon" sizes="96x96" href="images/manifest/icon-96x96.png">
+    <link rel="apple-touch-icon" sizes="144x144" href="images/manifest/icon-144x144.png">
+    <link rel="apple-touch-icon" sizes="192x192" href="images/manifest/icon-192x192.png">
 
     <!-- Tile icon for Windows 8 (144x144 + tile color) -->
-    <meta name="msapplication-TileImage" content="/images/manifest/icon-144x144.png">
+    <meta name="msapplication-TileImage" content="images/manifest/icon-144x144.png">
     <meta name="msapplication-TileColor" content="#3f51b5">
     <meta name="msapplication-tap-highlight" content="no">
 
     <!-- Load and register pre-caching Service Worker -->
     <script>
+      const baseUrl = document.querySelector('base').href;
+
       if ('serviceWorker' in navigator) {
         window.addEventListener('load', function() {
-          navigator.serviceWorker.register('/service-worker.js');
+          navigator.serviceWorker.register(baseUrl + 'service-worker.js');
         });
       }
     </script>
 
     <!-- Load webcomponents-loader.js to check and load any polyfills your browser needs -->
-    <script src="/bower_components/webcomponentsjs/webcomponents-loader.js"></script>
+    <script src="bower_components/webcomponentsjs/webcomponents-loader.js"></script>
 
     <!-- Load your application shell -->
-    <link rel="import" href="/src/my-app.html">
+    <link rel="import" href="src/my-app.html">
 
     <!-- Add any global styles for body, document, etc. -->
     <style>

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "My App",
   "short_name": "My App",
-  "start_url": "/?homescreen=1",
+  "start_url": "./?homescreen=1",
   "display": "standalone",
   "theme_color": "#3f51b5",
   "background_color": "#3f51b5",

--- a/src/my-app.html
+++ b/src/my-app.html
@@ -129,7 +129,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       constructor() {
         super();
 
-        // Get root pattern for app-route
+        // Get root pattern for app-route, for more information about `rootPath` see:
+        // https://www.polymer-project.org/2.0/docs/upgrade#urls-in-templates
         this.rootPattern = (new URL(this.rootPath)).pathname;
       }
 

--- a/src/my-app.html
+++ b/src/my-app.html
@@ -66,7 +66,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <app-location route="{{route}}"></app-location>
     <app-route
         route="{{route}}"
-        pattern="/:page"
+        pattern="[[rootPattern]]:page"
         data="{{routeData}}"
         tail="{{subroute}}"></app-route>
 
@@ -75,9 +75,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <app-drawer id="drawer" slot="drawer">
         <app-toolbar>Menu</app-toolbar>
         <iron-selector selected="[[page]]" attr-for-selected="name" class="drawer-list" role="navigation">
-          <a name="view1" href="/view1">View One</a>
-          <a name="view2" href="/view2">View Two</a>
-          <a name="view3" href="/view3">View Three</a>
+          <a name="view1" href="[[rootPath]]view1">View One</a>
+          <a name="view2" href="[[rootPath]]view2">View Two</a>
+          <a name="view3" href="[[rootPath]]view3">View Three</a>
         </iron-selector>
       </app-drawer>
 
@@ -124,6 +124,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         return [
           '_routePageChanged(routeData.page)',
         ];
+      }
+
+      constructor() {
+        super();
+
+        // Get root pattern for app-route
+        this.rootPattern = (new URL(this.rootPath)).pathname
       }
 
       _routePageChanged(page) {

--- a/src/my-app.html
+++ b/src/my-app.html
@@ -130,7 +130,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         super();
 
         // Get root pattern for app-route
-        this.rootPattern = (new URL(this.rootPath)).pathname
+        this.rootPattern = (new URL(this.rootPath)).pathname;
       }
 
       _routePageChanged(page) {

--- a/src/my-app.html
+++ b/src/my-app.html
@@ -75,9 +75,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <app-drawer id="drawer" slot="drawer">
         <app-toolbar>Menu</app-toolbar>
         <iron-selector selected="[[page]]" attr-for-selected="name" class="drawer-list" role="navigation">
-          <a name="view1" href="[[rootPath]]view1">View One</a>
-          <a name="view2" href="[[rootPath]]view2">View Two</a>
-          <a name="view3" href="[[rootPath]]view3">View Three</a>
+          <a name="view1" href="view1">View One</a>
+          <a name="view2" href="view2">View Two</a>
+          <a name="view3" href="view3">View Three</a>
         </iron-selector>
       </app-drawer>
 

--- a/src/my-app.html
+++ b/src/my-app.html
@@ -129,7 +129,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       constructor() {
         super();
 
-        // Get root pattern for app-route, for more information about `rootPath` see:
+        // Get root pattern for app-route, for more info about `rootPath` see:
         // https://www.polymer-project.org/2.0/docs/upgrade#urls-in-templates
         this.rootPattern = (new URL(this.rootPath)).pathname;
       }

--- a/src/my-view404.html
+++ b/src/my-view404.html
@@ -20,11 +20,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     </style>
 
-    <!--
-      If deploying in a folder replace href="/" with the full path to your site.
-      Such as: href=="http://polymerelements.github.io/polymer-starter-kit"
-    -->
-    Oops you hit a 404. <a href="/">Head back to home.</a>
+    Oops you hit a 404. <a href="[[rootPath]]">Head back to home.</a>
   </template>
 
   <script>


### PR DESCRIPTION
(PSK 3.0/2.0-preview) Implements relative paths as talked about on #981 without using `use-hash-as-path`.

Uses a `<base>` tag with Polymer's `rootPath`.

Here's a live preview built using `polymer build`, and using a pretty generic `.htaccess` for routing:
[PSK on non-root directory](https://silverlinkz.net/_test/polymer/2.0-relative-starter-kit/)

Basically functions the same as current PSK, but much easier to use on subdirectories by simple changing the `<base>`  tag `href`, and having the routes automatically change accordingly.

PS: This method can also be used for PSK 2.0 after `Polymer#1.9.0` lands with backport for `rootPath`.