### PR TITLE
Remove Node v4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,8 @@ addons:
     packages:
       - google-chrome-stable
 node_js:
+  - 'node'
   - '6'
-  - '5'
-  - '4'
 before_script:
   - npm install -g polymer-cli@next
   - polymer install


### PR DESCRIPTION
The Polymer CLI removes Node v4 support.

>Remove Node v4 support: Node v4 is no longer in Active LTS, so as per the Polymer Tools Node.js Support Policy the Polymer CLI will not support Node v4. Please update to Node v6 or later to continue using the latest verisons of Polymer tooling.

[Polymer CLI - CHANGELOG.md v0.18.0 [04-13-2017]](https://github.com/Polymer/polymer-cli/blob/master/CHANGELOG.md#v0180-04-13-2017)