### PR TITLE
Use relative paths with Polymer v1 Starter Kit

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,7 @@
     "iron-pages": "PolymerElements/iron-pages#^1.0.0",
     "iron-selector": "PolymerElements/iron-selector#^1.0.0",
     "paper-icon-button": "PolymerElements/paper-icon-button#~1.1.0",
-    "polymer": "Polymer/polymer#^1.6.0"
+    "polymer": "Polymer/polymer#^1.9.0"
   },
   "devDependencies": {
     "web-component-tester": "^4.0.0"

--- a/index.html
+++ b/index.html
@@ -19,14 +19,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <meta name="description" content="My App description">
 
     <!--
-      When deploying to a non-root path, transform the base href by adding an
-      absolute reference to the root path your application will be deployed to, by either:
+      The `<base>` tag below is present to support two advanced deployment options:
+      1) Differential serving. 2) Serving from a non-root path.
 
-      - Adding a `basePath` property to your build configuration in `polymer.json`.
-        For example: { "preset": "es5-bundled", "basePath": "/subfolder/app-root/" }
+      Instead of manually editing the `<base>` tag yourself, you should generally either:
+      a) Add a `basePath` property to the build configuration in your `polymer.json`.
+      b) Use the `--base-path` command-line option for `polymer build`.
 
-      - Using the `--base-path` command line flag for polymer build in the CLI.
-        For example: polymer build --base-path /subfolder/app-root/
+      Note: If you intend to serve from a non-root path, you will also need to manually
+      comment out one line of JavaScript, see [polymer-root-path] below.
     -->
     <base href="/">
 
@@ -65,6 +66,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         dom: 'shadow',
         lazyRegister: true,
       };
+
+      // [polymer-root-path] By default, we set `Polymer.rootPath` to the server root path
+      // to support differential serving; this setting is also compatible with standard,
+      // single-build deployments. If you intend to serve your app from a non-root path,
+      // comment out the line below.
+      window.Polymer.rootPath = window.location.origin;
 
       // Load webcomponentsjs polyfill if browser does not support native
       // Web Components

--- a/index.html
+++ b/index.html
@@ -18,10 +18,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <title>My App</title>
     <meta name="description" content="My App description">
 
-    <link rel="icon" href="/images/favicon.ico">
+    <!--
+      If deploying to a non-root path, replace href="/" with the full path to the project root.
+      For example: href="/polymer-starter-kit/relative-path-example/"
+    -->
+    <base href="/">
+
+    <link rel="icon" href="images/favicon.ico">
 
     <!-- See https://goo.gl/OOhYW5 -->
-    <link rel="manifest" href="/manifest.json">
+    <link rel="manifest" href="manifest.json">
 
     <!-- See https://goo.gl/qRE0vM -->
     <meta name="theme-color" content="#3f51b5">
@@ -36,14 +42,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <meta name="apple-mobile-web-app-title" content="My App">
 
     <!-- Homescreen icons -->
-    <link rel="apple-touch-icon" href="/images/manifest/icon-48x48.png">
-    <link rel="apple-touch-icon" sizes="72x72" href="/images/manifest/icon-72x72.png">
-    <link rel="apple-touch-icon" sizes="96x96" href="/images/manifest/icon-96x96.png">
-    <link rel="apple-touch-icon" sizes="144x144" href="/images/manifest/icon-144x144.png">
-    <link rel="apple-touch-icon" sizes="192x192" href="/images/manifest/icon-192x192.png">
+    <link rel="apple-touch-icon" href="images/manifest/icon-48x48.png">
+    <link rel="apple-touch-icon" sizes="72x72" href="images/manifest/icon-72x72.png">
+    <link rel="apple-touch-icon" sizes="96x96" href="images/manifest/icon-96x96.png">
+    <link rel="apple-touch-icon" sizes="144x144" href="images/manifest/icon-144x144.png">
+    <link rel="apple-touch-icon" sizes="192x192" href="images/manifest/icon-192x192.png">
 
     <!-- Tile icon for Windows 8 (144x144 + tile color) -->
-    <meta name="msapplication-TileImage" content="/images/manifest/icon-144x144.png">
+    <meta name="msapplication-TileImage" content="images/manifest/icon-144x144.png">
     <meta name="msapplication-TileColor" content="#3f51b5">
     <meta name="msapplication-tap-highlight" content="no">
 
@@ -53,6 +59,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         dom: 'shadow',
         lazyRegister: true,
       };
+
+      var baseUrl = document.querySelector('base').href;
 
       // Load webcomponentsjs polyfill if browser does not support native
       // Web Components
@@ -78,7 +86,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         if (!webComponentsSupported) {
           var script = document.createElement('script');
           script.async = true;
-          script.src = '/bower_components/webcomponentsjs/webcomponents-lite.min.js';
+          script.src = baseUrl + 'bower_components/webcomponentsjs/webcomponents-lite.min.js';
           script.onload = onload;
           document.head.appendChild(script);
         } else {
@@ -89,12 +97,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // Load pre-caching Service Worker
       if ('serviceWorker' in navigator) {
         window.addEventListener('load', function() {
-          navigator.serviceWorker.register('/service-worker.js');
+          navigator.serviceWorker.register(baseUrl + 'service-worker.js');
         });
       }
     </script>
 
-    <link rel="import" href="/src/my-app.html">
+    <link rel="import" href="src/my-app.html">
 
     <style>
       body {

--- a/index.html
+++ b/index.html
@@ -19,8 +19,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <meta name="description" content="My App description">
 
     <!--
-      If deploying to a non-root path, replace href="/" with the full path to the project root.
+      If deploying to a non-root path, replace href="/" with an
+      absolute reference to the root path your application will deploy to.
       For example: href="/polymer-starter-kit/relative-path-example/"
+
+      Note: When serving locally with `polymer serve` this must be set to href="/".
     -->
     <base href="/">
 

--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // Load pre-caching Service Worker
       if ('serviceWorker' in navigator) {
         window.addEventListener('load', function() {
-          navigator.serviceWorker.register('service-worker.js');
+          navigator.serviceWorker.register('service-worker.js', {scope: Polymer.rootPath});
         });
       }
     </script>

--- a/index.html
+++ b/index.html
@@ -102,7 +102,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // Load pre-caching Service Worker
       if ('serviceWorker' in navigator) {
         window.addEventListener('load', function() {
-          navigator.serviceWorker.register('service-worker.js', {scope: Polymer.rootPath});
+          navigator.serviceWorker.register('service-worker.js', {
+            scope: Polymer.rootPath,
+          });
         });
       }
     </script>

--- a/index.html
+++ b/index.html
@@ -87,7 +87,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         if (!webComponentsSupported) {
           var script = document.createElement('script');
           script.async = true;
-          script.src = baseUrl + 'bower_components/webcomponentsjs/webcomponents-lite.min.js';
+          script.src = baseUrl +
+            'bower_components/webcomponentsjs/webcomponents-lite.min.js';
           script.onload = onload;
           document.head.appendChild(script);
         } else {

--- a/index.html
+++ b/index.html
@@ -67,10 +67,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         lazyRegister: true,
       };
 
-      // [polymer-root-path] By default, we set `Polymer.rootPath` to the server root path
-      // to support differential serving; this setting is also compatible with standard,
-      // single-build deployments. If you intend to serve your app from a non-root path,
-      // comment out the line below.
+      // [polymer-root-path] By default, we set `Polymer.rootPath` to the
+      // server root path to support differential serving; this setting is also
+      // compatible with standard, single-build deployments. If you intend to
+      // serve your app from a non-root path, comment out the line below.
       window.Polymer.rootPath = window.location.origin;
 
       // Load webcomponentsjs polyfill if browser does not support native

--- a/index.html
+++ b/index.html
@@ -60,6 +60,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         lazyRegister: true,
       };
 
+      // Register the base URL
       var baseUrl = document.querySelector('base').href;
 
       // Load webcomponentsjs polyfill if browser does not support native

--- a/index.html
+++ b/index.html
@@ -19,11 +19,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <meta name="description" content="My App description">
 
     <!--
-      If deploying to a non-root path, replace href="/" with an
-      absolute reference to the root path your application will deploy to.
-      For example: href="/polymer-starter-kit/relative-path-example/"
+      When deploying to a non-root path, transform the base href by adding an
+      absolute reference to the root path your application will be deployed to, by either:
 
-      Note: When serving locally with `polymer serve` this must be set to href="/".
+      - Adding a `basePath` property to your build configuration in `polymer.json`.
+        For example: { "preset": "es5-bundled", "basePath": "/subfolder/app-root/" }
+
+      - Using the `--base-path` command line flag for polymer build in the CLI.
+        For example: polymer build --base-path /subfolder/app-root/
     -->
     <base href="/">
 

--- a/index.html
+++ b/index.html
@@ -63,9 +63,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         lazyRegister: true,
       };
 
-      // Register the base URL
-      var baseUrl = document.querySelector('base').href;
-
       // Load webcomponentsjs polyfill if browser does not support native
       // Web Components
       (function() {
@@ -90,7 +87,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         if (!webComponentsSupported) {
           var script = document.createElement('script');
           script.async = true;
-          script.src = baseUrl +
+          script.src =
             'bower_components/webcomponentsjs/webcomponents-lite.min.js';
           script.onload = onload;
           document.head.appendChild(script);
@@ -102,7 +99,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // Load pre-caching Service Worker
       if ('serviceWorker' in navigator) {
         window.addEventListener('load', function() {
-          navigator.serviceWorker.register(baseUrl + 'service-worker.js');
+          navigator.serviceWorker.register('service-worker.js');
         });
       }
     </script>

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "My App",
   "short_name": "My App",
-  "start_url": "/?homescreen=1",
+  "start_url": "./?homescreen=1",
   "display": "standalone",
   "theme_color": "#3f51b5",
   "background_color": "#3f51b5",

--- a/src/my-app.html
+++ b/src/my-app.html
@@ -113,13 +113,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       observers: [
+        '_setRootPattern(rootPath)',
         '_routePageChanged(routeData.page)',
       ],
 
-      ready: function() {
+      _setRootPattern: function(rootPath) {
         // Get root pattern for app-route, for more info about `rootPath` see:
         // https://www.polymer-project.org/2.0/docs/upgrade#urls-in-templates
-        this.rootPattern = (new URL(this.rootPath)).pathname;
+        this.rootPattern = (new URL(rootPath)).pathname;
       },
 
       _routePageChanged: function(page) {

--- a/src/my-app.html
+++ b/src/my-app.html
@@ -61,7 +61,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <app-location route="{{route}}"></app-location>
     <app-route
         route="{{route}}"
-        pattern="/:page"
+        pattern="[[rootPattern]]:page"
         data="{{routeData}}"
         tail="{{subroute}}"></app-route>
 
@@ -70,9 +70,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <app-drawer id="drawer">
         <app-toolbar>Menu</app-toolbar>
         <iron-selector selected="[[page]]" attr-for-selected="name" class="drawer-list" role="navigation">
-          <a name="view1" href="/view1">View One</a>
-          <a name="view2" href="/view2">View Two</a>
-          <a name="view3" href="/view3">View Three</a>
+          <a name="view1" href="[[rootPath]]view1">View One</a>
+          <a name="view2" href="[[rootPath]]view2">View Two</a>
+          <a name="view3" href="[[rootPath]]view3">View Three</a>
         </iron-selector>
       </app-drawer>
 
@@ -115,6 +115,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       observers: [
         '_routePageChanged(routeData.page)',
       ],
+
+      ready: function() {
+        // Get root pattern for app-route, for more info about `rootPath` see:
+        // https://www.polymer-project.org/2.0/docs/upgrade#urls-in-templates
+        this.rootPattern = (new URL(this.rootPath)).pathname;
+      },
 
       _routePageChanged: function(page) {
         this.page = page || 'view1';

--- a/src/my-app.html
+++ b/src/my-app.html
@@ -109,6 +109,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           type: String,
           computed: '_computeRootPattern(rootPath)',
         },
+
         page: {
           type: String,
           reflectToAttribute: true,

--- a/src/my-app.html
+++ b/src/my-app.html
@@ -105,6 +105,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       is: 'my-app',
 
       properties: {
+        rootPattern: {
+          type: String,
+          computed: '_computeRootPattern(rootPath)',
+        },
         page: {
           type: String,
           reflectToAttribute: true,
@@ -113,14 +117,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       observers: [
-        '_setRootPattern(rootPath)',
         '_routePageChanged(routeData.page)',
       ],
 
-      _setRootPattern: function(rootPath) {
+      _computeRootPattern: function(rootPath) {
         // Get root pattern for app-route, for more info about `rootPath` see:
         // https://www.polymer-project.org/2.0/docs/upgrade#urls-in-templates
-        this.rootPattern = (new URL(rootPath)).pathname;
+        return (new URL(rootPath)).pathname;
       },
 
       _routePageChanged: function(page) {

--- a/src/my-view404.html
+++ b/src/my-view404.html
@@ -20,11 +20,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     </style>
 
-    <!-- 
-      If deploying in a folder replace href="/" with the full path to your site.
-      Such as: href=="http://polymerelements.github.io/polymer-starter-kit"
-    -->
-    Oops you hit a 404. <a href="/">Head back to home.</a>
+    Oops you hit a 404. <a href="[[rootPath]]">Head back to home.</a>
   </template>
 
   <script>

--- a/sw-precache-config.js
+++ b/sw-precache-config.js
@@ -12,9 +12,9 @@
 
 module.exports = {
   staticFileGlobs: [
-    '/index.html',
-    '/manifest.json',
-    '/bower_components/webcomponentsjs/webcomponents-lite.min.js',
+    'index.html',
+    'manifest.json',
+    'bower_components/webcomponentsjs/webcomponents-lite.min.js',
   ],
   navigateFallback: 'index.html',
 };


### PR DESCRIPTION
#### Polymer v1 / PSK 2.0 version of #995, basically the same with a few differences for Polymer v1 support.
1. Since `created` is called too early, and `ready` too late, ~~uses an observer to set `rootPattern`.~~ **Now uses a computed property**
1. Since Polymer v1 rewrites paths based on import path it requires `rootPath` bindings for `view` links. (Also works in Polymer 2, but not necessary.) **`rootPath` bindings will also be added to `2.0-preview`**
1. ~~Update Polymer dependency to `1.9.0` for `rootPath` support.~~ **Already done on master**

Due to the differences in rewriting of paths I'm not sure where this fits in continuity between PSK 2.0 and PSK 3.0, ease of use for new users, and ease of use when deploying to a subdirectory.

#### Live Demos
[Simple Build](https://silverlinkz.net/_test/polymer/relative-starter-kit/)
[Bundled & Minified Build](https://silverlinkz.net/_test/polymer/relative-starter-kit-bundled/)
