### PR TITLE
[2.0-preview] Bring 2.0-preview in line with polymer 1 tentative changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // server root path to support differential serving; this setting is also
       // compatible with standard, single-build deployments. If you intend to
       // serve your app from a non-root path, comment out the line below.
-      window.Polymer.rootPath = window.location.origin;
+      window.Polymer = {rootPath: window.location.origin};
 
       // Load and register pre-caching Service Worker
       if ('serviceWorker' in navigator) {

--- a/index.html
+++ b/index.html
@@ -61,11 +61,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <meta name="msapplication-tap-highlight" content="no">
 
     <script>
+      // Use a regex for `window.location.origin` for compatibility with IE11.
+      const locationOrigin = window.location.href.match(/^.+?\/\/.*?\//)[0];
+
       // [polymer-root-path] By default, we set `Polymer.rootPath` to the
       // server root path to support differential serving; this setting is also
       // compatible with standard, single-build deployments. If you intend to
       // serve your app from a non-root path, comment out the line below.
-      window.Polymer = {rootPath: window.location.origin};
+      window.Polymer = {rootPath: locationOrigin};
 
       // Load and register pre-caching Service Worker
       if ('serviceWorker' in navigator) {


### PR DESCRIPTION
Remove `baseUrl` and path concatenation to bring the 2.0-preview branch in line with the tentative polymer 1 starter kit relative path changes. REF: #1008 

**Question 1**: Should I also change `basePattern` to use a computed property?

I don't mind either constructor or computed property personally, but since it's a computed property in the polymer 1 starter kit and we already have the property defined for `polymer lint`, I'm thinking maybe we should switch it?

**~~Question 2~~**: In the live previews (listed below) I noticed the generated service worker is failing for now on relative paths, I believe this is fixed soon (?), but for now, should we change paths in `sw-precache-config.js` to relative, or are they fine since they would be rewritten the for base path anyways?

**Regarding Question 2**: Updated paths to relative in `sw-precache-config.js`.

#### Live Previews:
[es5-bundled preset](https://silverlinkz.net/_test/polymer/psk3-relative/es5-bundled/)
[es6-unbundled preset](https://silverlinkz.net/_test/polymer/psk3-relative/es6-unbundled/)