### PR TITLE
Add regex for use with IE11 instead of URL()

### DIFF
--- a/src/my-app.html
+++ b/src/my-app.html
@@ -142,7 +142,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // https://www.polymer-project.org/2.0/docs/upgrade#urls-in-templates
 
         // If URL API isn't supported (IE11), use a regex for the URL pathname.
-        if (!URL.prototype || !('pathname' in URL.prototype)) {
+        if (!(URL.prototype && 'pathname' in URL.prototype)) {
           return rootPath.replace(/^.+?\/\/?.*?\/|$/, '/');
         }
 

--- a/src/my-app.html
+++ b/src/my-app.html
@@ -140,8 +140,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       computeRootPattern(rootPath) {
         // Get root pattern for app-route, for more info about `rootPath` see:
         // https://www.polymer-project.org/2.0/docs/upgrade#urls-in-templates
-        if (window.URL && window.URL.prototype && ('href' in window.URL.prototype)) {
-          // Use `new URL()` if supported by the browser.
+        if (window.URL && window.URL.prototype &&
+            ('href' in window.URL.prototype)) {
           return (new URL(rootPath)).pathname;
         } else {
           // Use a regex if `new URL()` isn't supported. (IE11)

--- a/src/my-app.html
+++ b/src/my-app.html
@@ -140,13 +140,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       computeRootPattern(rootPath) {
         // Get root pattern for app-route, for more info about `rootPath` see:
         // https://www.polymer-project.org/2.0/docs/upgrade#urls-in-templates
-        if (window.URL && window.URL.prototype &&
-            ('href' in window.URL.prototype)) {
-          return (new URL(rootPath)).pathname;
-        } else {
-          // Use a regex if `new URL()` isn't supported. (IE11)
-          return rootPath.replace(/^(.+?\/\/)?(.*?)(\/|$)/, '/');
+
+        // Use a regex if URL API isn't supported. (IE11)
+        if (!URL.prototype || !('pathname' in URL.prototype)) {
+          return rootPath.replace(/^.+?\/\/?.*?\/|$/, '/');
         }
+
+        return (new URL(rootPath)).pathname;
       }
 
       _routePageChanged(page) {

--- a/src/my-app.html
+++ b/src/my-app.html
@@ -122,7 +122,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             reflectToAttribute: true,
             observer: '_pageChanged',
           },
-          rootPattern: String,
+          rootPattern: {
+            type: String,
+            computed: 'computeRootPattern(rootPath)',
+          },
           routeData: Object,
           subroute: String,
         };
@@ -134,12 +137,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         ];
       }
 
-      constructor() {
-        super();
-
+      computeRootPattern(rootPath) {
         // Get root pattern for app-route, for more info about `rootPath` see:
         // https://www.polymer-project.org/2.0/docs/upgrade#urls-in-templates
-        this.rootPattern = (new URL(this.rootPath)).pathname;
+        if (window.URL && window.URL.prototype && ('href' in window.URL.prototype)) {
+          // Use `new URL()` if supported by the browser.
+          return (new URL(rootPath)).pathname;
+        } else {
+          // Use a regex if `new URL()` isn't supported. (IE11)
+          return rootPath.replace(/^(.+?\/\/)?(.*?)(\/|$)/, '/');
+        }
       }
 
       _routePageChanged(page) {

--- a/src/my-app.html
+++ b/src/my-app.html
@@ -141,7 +141,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // Get root pattern for app-route, for more info about `rootPath` see:
         // https://www.polymer-project.org/2.0/docs/upgrade#urls-in-templates
 
-        // Use a regex if URL API isn't supported. (IE11)
+        // If URL API isn't supported (IE11), use a regex for the URL pathname.
         if (!URL.prototype || !('pathname' in URL.prototype)) {
           return rootPath.replace(/^.+?\/\/?.*?\/|$/, '/');
         }


### PR DESCRIPTION
So it turns out that `new URL(...)` isn't supported on IE11, this fix uses the same method on supported browsers, but uses a regex on unsupported browsers.

I wasn't sure if I should just change it to the regex, so for now I kept both with a check for compatibility and moved it all to a computed function to clean it up a bit. This also brings it in line with the pattern used on the tentative Polymer 1 PSK changes. (Will update #master PR with fix after this is finalized.)

If there's a cleaner way to do this, please lmk!

Fixes #1020