### PR TITLE
Simpler support for differential serving, non-root-path deployments

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       b) Use the `--base-path` command-line option for `polymer build`.
 
       Note: If you intend to serve from a non-root path, you will also need to manually
-      comment out one line of JavaScript, see [polymer-root-path] below.
+      edit one line of JavaScript, see [polymer-root-path] below.
     -->
     <base href="/">
 
@@ -62,10 +62,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <script>
       // [polymer-root-path] By default, we set `Polymer.rootPath` to the
-      // server root path to support differential serving; this setting is also
-      // compatible with standard, single-build deployments. If you intend to
-      // serve your app from a non-root path, comment out the line below.
-      window.Polymer.rootPath = window.location.origin;
+      // server root path (`/`). Leave this line unchanged if you intend to serve
+      // your app from the root path (e.g., if users will access your app from
+      // URLs like `https://my.domain/`, `https://my.domain/view1`, etc.).
+      //
+      // If you intend to serve your app from a non-root path (e.g., with URLs
+      // like `https://my.domain/my-app/` and `https://my.domain/my-app/view1`),
+      // edit this line to indicate the path from which you'll be serving (e.g.
+      // `/my-app/`).
+      window.Polymer = {rootPath: '/'};
 
       // Load and register pre-caching Service Worker
       if ('serviceWorker' in navigator) {

--- a/index.html
+++ b/index.html
@@ -26,8 +26,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       a) Add a `basePath` property to the build configuration in your `polymer.json`.
       b) Use the `--base-path` command-line option for `polymer build`.
 
-      Note: If you intend to serve from a non-root path, you will also need to manually
-      edit one line of JavaScript, see [polymer-root-path] below.
+      Note: If you intend to serve from a non-root path, see [polymer-root-path] below.
     -->
     <base href="/">
 
@@ -61,15 +60,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <meta name="msapplication-tap-highlight" content="no">
 
     <script>
-      // [polymer-root-path] By default, we set `Polymer.rootPath` to the
-      // server root path (`/`). Leave this line unchanged if you intend to serve
-      // your app from the root path (e.g., if users will access your app from
-      // URLs like `https://my.domain/`, `https://my.domain/view1`, etc.).
-      //
-      // If you intend to serve your app from a non-root path (e.g., with URLs
-      // like `https://my.domain/my-app/` and `https://my.domain/my-app/view1`),
-      // edit this line to indicate the path from which you'll be serving (e.g.
-      // `/my-app/`).
+      /**
+      * [polymer-root-path]
+      *
+      * By default, we set `Polymer.rootPath` to the server root path (`/`).
+      * Leave this line unchanged if you intend to serve your app from the root
+      * path (e.g., with URLs like `my.domain/` and `my.domain/view1`).
+      *
+      * If you intend to serve your app from a non-root path (e.g., with URLs
+      * like `my.domain/my-app/` and `my.domain/my-app/view1`), edit this line
+      * to indicate the path from which you'll be serving, including leading
+      * and trailing slashes (e.g., `/my-app/`).
+      */
       window.Polymer = {rootPath: '/'};
 
       // Load and register pre-caching Service Worker

--- a/polymer.json
+++ b/polymer.json
@@ -21,16 +21,13 @@
   },
   "builds": [
     {
-      "preset": "es5-bundled",
-      "basePath": true
+      "preset": "es5-bundled"
     },
     {
-      "preset": "es6-bundled",
-      "basePath": true
+      "preset": "es6-bundled"
     },
     {
-      "preset": "es6-unbundled",
-      "basePath": true
+      "preset": "es6-unbundled"
     }
   ]
 }

--- a/src/my-app.html
+++ b/src/my-app.html
@@ -71,7 +71,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <app-location route="{{route}}"></app-location>
     <app-route
         route="{{route}}"
-        pattern="[[rootPattern]]:page"
+        pattern="[[rootPath]]:page"
         data="{{routeData}}"
         tail="{{subroute}}"></app-route>
 
@@ -121,10 +121,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             reflectToAttribute: true,
             observer: '_pageChanged',
           },
-          rootPattern: {
-            type: String,
-            computed: 'computeRootPattern(rootPath)',
-          },
           routeData: Object,
           subroute: String,
           // This shouldn't be neccessary, but the Analyzer isn't picking up
@@ -137,18 +133,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         return [
           '_routePageChanged(routeData.page)',
         ];
-      }
-
-      computeRootPattern(rootPath) {
-        // Get root pattern for app-route, for more info about `rootPath` see:
-        // https://www.polymer-project.org/2.0/docs/upgrade#urls-in-templates
-
-        // If URL API isn't supported (IE11), use a regex for the URL pathname.
-        if (!(URL.prototype && 'pathname' in URL.prototype)) {
-          return rootPath.replace(/^.+?\/\/?.*?\/|$/, '/');
-        }
-
-        return (new URL(rootPath)).pathname;
       }
 
       _routePageChanged(page) {

--- a/src/my-app.html
+++ b/src/my-app.html
@@ -68,7 +68,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     </style>
 
-    <app-location route="{{route}}"></app-location>
+    <app-location route="{{route}}" url-space-regex="[[rootPath]]*"></app-location>
     <app-route
         route="{{route}}"
         pattern="[[rootPath]]:page"


### PR DESCRIPTION
This PR, based on @arthurevans's comments on #1008, is a simpler implementation of support for differential serving and non-root-path deployments.

The key difference is that we set `Polymer.rootPath` to a server-relative path with a leading slash, instead of mimicking its "natural" form (a full URL). We default to `/`, which works for differential serving and for standard, single-build deployments from the server root. For non-root-path deployments, devs will manually edit it to specify the path from which they'll serve (e.g. `/my-app/`).

This eliminates the need for the computed `rootPattern` property, since that property was just massaging `rootPath` into the form that we're now using directly.

Also: added `url-space-regex` property to `<app-location>` to filter out URL changes not beneath the app's root path, so that the app's router won't hijack navigations attempting to move outside the app.

Would still like to provide more detailed info in the README, but saving that for a separate PR.

This PR should supersede #1019.

cc @jsilvermist