### PR TITLE
Update polymer init instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ Second, install [Bower](https://bower.io/) using [npm](https://www.npmjs.com)
 
     mkdir my-app
     cd my-app
-    polymer init starter-kit
+    polymer init
+    # select from listed options
 
 ### Start the development server
 


### PR DESCRIPTION
`polymer init starter-kit` appears to be deprecated in polymer-cli 1.2.0

Fixes https://github.com/PolymerElements/polymer-starter-kit/issues/1039