### PR TITLE
Remove unneeded check

### DIFF
--- a/src/my-app.html
+++ b/src/my-app.html
@@ -136,12 +136,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       _routePageChanged(page) {
-        // Polymer 2.0 will call with `undefined` on initialization.
-        // Ignore until we are properly called with a string.
-        if (page === undefined) {
-          return;
-        }
-
         // If no page was found in the route data, page will be an empty string.
         // Deault to 'view1' in that case.
         this.page = page || 'view1';


### PR DESCRIPTION
I think this had to be during the preview, because now it's never `undefined `.

Was added by @FredKSchott at #967.