### PR TITLE
Update manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,21 +2,20 @@
   "name": "My App",
   "short_name": "My App",
   "description": "My App description",
-  "start_url": "./?utm_source=web_app_manifest",
-  "scope": "./",
-  "display": "standalone",
-  "theme_color": "#3f51b5",
-  "background_color": "#3f51b5",
   "icons": [
     {
-      "src": "./images/manifest/icon-192x192.png",
+      "src": "images/manifest/icon-192x192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "./images/manifest/icon-512x512.png",
+      "src": "images/manifest/icon-512x512.png",
       "sizes": "512x512",
       "type": "image/png"
     }
-  ]
+  ],
+  "start_url": "/",
+  "display": "standalone",
+  "theme_color": "#3f51b5",
+  "background_color": "#3f51b5",
 }

--- a/manifest.json
+++ b/manifest.json
@@ -17,5 +17,5 @@
   "start_url": "/",
   "display": "standalone",
   "theme_color": "#3f51b5",
-  "background_color": "#3f51b5",
+  "background_color": "#3f51b5"
 }


### PR DESCRIPTION
In light of the changes in #1049 and discussions linked to from that PR, we're updating the web manifest to be consistent with Shop and News.

* `start_url` is set to absolute `/`. This is because with [prpl-server](https://github.com/Polymer/prpl-server-node), manifest.json is served from the build-specific directory (e.g. /es6-bundled/manifest.json), and the manifest needs to cover URLs outside of that directory (e.g. "/", or "/list/1")
  * Analytics params (`utm_*`) will be excluded and left to user's [choice](https://w3c.github.io/manifest/#privacy-consideration:-start_url-tracking)
* `scope` will be left undefined. It is assumed that everything on the same origin is in scope.
* icon `src`s are always relative to manifest.json, (even with prpl-server when they would be served from /es6-bundled/images/manifest/...png)

As a result of these changes, serving the app out of a non-root URL (e.g. example.com/my-app/) will require changes to the manifest. Changes are already required in other parts of the app (e.g. the `<base>` tag in index.html), so this wouldn't be a new issue.