### PR TITLE
Fix: Make colors consistent by using hex

### DIFF
--- a/src/my-app.html
+++ b/src/my-app.html
@@ -32,7 +32,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <style>
       :host {
         --app-primary-color: #4285f4;
-        --app-secondary-color: black;
+        --app-secondary-color: #000;
 
         display: block;
       }
@@ -47,7 +47,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       app-header paper-icon-button {
-        --paper-icon-button-ink-color: white;
+        --paper-icon-button-ink-color: #fff;
       }
 
       .drawer-list {
@@ -63,7 +63,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       .drawer-list a.iron-selected {
-        color: black;
+        color: #000;
         font-weight: bold;
       }
     </style>


### PR DESCRIPTION
everywhere else in the app uses hex even for `white` there are already usages of `#fff`