### PR TITLE
fix(readme): remove @next

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The PRPL pattern, in a nutshell:
 Install [Polymer CLI](https://github.com/Polymer/polymer-cli) using
 [npm](https://www.npmjs.com) (we assume you have pre-installed [node.js](https://nodejs.org)).
 
-    npm install -g polymer-cli@next
+    npm install -g polymer-cli
 
 ##### Initialize project from template
 


### PR DESCRIPTION
`polymer-cli@next` install `1.7.0-pre.17` but 1.7.2 is available now